### PR TITLE
fix(layout): resolve contextual dash and ellipsis roles

### DIFF
--- a/docs/adr/0003-prefer-clreq-recommended-codepoints.md
+++ b/docs/adr/0003-prefer-clreq-recommended-codepoints.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-06-06
+- Amended: 2026-08-30 (`ContextualDashEllipsisRoleResolution`)
 
 ## Context
 
@@ -31,7 +32,11 @@ source "・" "‧" "•" 等  vs  间隔号 "·"
 "・" "‧" "•" -> "·"
 ```
 
-「只分类不替换」的字符（连接号 ~ – —、分隔号 / ／、句号变体 ．、双叹号 ‼、双问号 ⁇）只在 fallback 上倾向 CJK 字体，不改 code point。
+替换入口还必须检查最终字体角色；只有上下文已经解析为 `CjkPunctuation` 的 source run
+可以应用上述候选。西文角色即使因样式边界成为独立 shaping segment，也保留 source display。
+
+「只分类不替换」的字符（连接号 ~ – —、分隔号 / ／、句号变体 ．、双叹号 ‼、双问号 ⁇）
+不改 code point；其中 U+2014 按下文的上下文规则选择字体角色，其余继续使用既有分类与 fallback。
 
 ## Consequences
 
@@ -108,3 +113,16 @@ range、复制、搜索和无障碍语义始终按原始 U+2026 处理。
 标记为 `UnverifiedDisplaySubstitutionCoverage`，公共 pipeline 以
 `SubstitutionRollbackOnUnverifiedGlyphCoverage` 回到 U+2026。这里宁可保留 source 字形，
 也不把浏览器能从某个系统 fallback 画出 U+22EF 误报成当前字体覆盖。
+
+### Amendment (2026-08-30): ContextualDashEllipsisRoleResolution
+
+U+2014 与 U+2026 同时用于中文和西文，不能再按码点一律归到 CJK，也不能用一个或两个连续码点
+猜测语言。连续字符只形成待判定的 source run；字体角色由 run 两侧最近的 Unicode 强脚本文本
+决定。两侧一致或仅一侧有证据时继承该侧，两侧冲突或都没有证据时使用段落 locale；强制换行
+截断上下文搜索。决定以 `DashEllipsisSurroundingScriptContext` 或
+`ParagraphLanguageDashEllipsisContext` 进入 `LayoutResult.debug.roleOverrides`。
+
+`CjkRoleGatedDisplaySubstitution` 随后把 display 替换限制为最终角色为 `CjkPunctuation` 的 run。
+这使中文 `中—文`、`等…真` 即使只有一个标点仍使用 CJK 几何，而西文 `A——B`、
+`Wait……what` 即使重复两个标点也保持 Latin face 与 source display。source range、复制、搜索、
+选择和无障碍语义继续保持不变。

--- a/docs/adr/0003-prefer-clreq-recommended-codepoints.md
+++ b/docs/adr/0003-prefer-clreq-recommended-codepoints.md
@@ -127,6 +127,12 @@ U+2014 与 U+2026 同时用于中文和西文，不能再按码点一律归到 C
 判为西文的 run 仍保持独立 cluster（`ContextualDashEllipsisRunSegmentation`），不并入相邻的
 Latin 词 cluster；断行类在 run 边界提供的机会因此与角色解析前一致。
 
+`ParentheticalDashPairContext`：相邻两个等长的纯 U+2014 run，且中间内容全部为词字符或
+ASCII 空格时，构成一个插入语对并联合决议。证据只取对外侧（首 run 左邻与尾 run 右邻的
+最近强脚本），一致或仅一侧有证据时继承该侧，冲突或缺失时回段落 locale；插入内容不投票，
+所以 `想Jessica——Jessica是他的前女友——睡不着` 两个破折号同为 CJK 面。中间出现任何
+其他字符（句读、符号、强制换行）时两个 run 保持独立，省略号 run 不参与配对。
+
 `CjkRoleGatedDisplaySubstitution` 随后把 display 替换限制为最终角色为 `CjkPunctuation` 的 run。
 这使中文 `中—文`、`等…真` 即使只有一个标点仍使用 CJK 几何，而西文 `A——B`、
 `Wait……what` 即使重复两个标点也保持 Latin face 与 source display。source range、复制、搜索、

--- a/docs/adr/0003-prefer-clreq-recommended-codepoints.md
+++ b/docs/adr/0003-prefer-clreq-recommended-codepoints.md
@@ -119,8 +119,13 @@ range、复制、搜索和无障碍语义始终按原始 U+2026 处理。
 U+2014 与 U+2026 同时用于中文和西文，不能再按码点一律归到 CJK，也不能用一个或两个连续码点
 猜测语言。连续字符只形成待判定的 source run；字体角色由 run 两侧最近的 Unicode 强脚本文本
 决定。两侧一致或仅一侧有证据时继承该侧，两侧冲突或都没有证据时使用段落 locale；强制换行
-截断上下文搜索。决定以 `DashEllipsisSurroundingScriptContext` 或
+截断上下文搜索。这一点与弯引号不同：弯引号按配对模型解析，引文本身可以跨强制换行，
+所以引号的上下文扫描不以换行为界；破折号与省略号是行内标点，不允许借用另一行的脚本证据。
+决定以 `DashEllipsisSurroundingScriptContext` 或
 `ParagraphLanguageDashEllipsisContext` 进入 `LayoutResult.debug.roleOverrides`。
+
+判为西文的 run 仍保持独立 cluster（`ContextualDashEllipsisRunSegmentation`），不并入相邻的
+Latin 词 cluster；断行类在 run 边界提供的机会因此与角色解析前一致。
 
 `CjkRoleGatedDisplaySubstitution` 随后把 display 替换限制为最终角色为 `CjkPunctuation` 的 run。
 这使中文 `中—文`、`等…真` 即使只有一个标点仍使用 CJK 几何，而西文 `A——B`、

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,8 @@ box 放到语义正确的全宽字身一侧，再从该全宽字身计算压缩�
 Android、JVM 或 JS 自带的 Unicode 表。
 同为 Common 的 U+2014 破折号与 U+2026 省略号按连续 source run 解析两侧最近的强脚本文本；
 连续数量只界定待判定的 source run，不参与中西角色选择。两侧冲突或无证据时使用段落语言，强制换行截断
-搜索。只有最终判为 `CjkPunctuation` 的 run 才能进入 CLREQ display 码点替换。
+搜索；弯引号的配对模型允许引文跨行，其上下文不以换行为界。run 无论判为哪一侧都保持独立
+cluster，只有最终判为 `CjkPunctuation` 的 run 才能进入 CLREQ display 码点替换。
 
 ## 排版核心
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,6 +135,9 @@ box 放到语义正确的全宽字身一侧，再从该全宽字身计算压缩�
 泄漏为下一对的外层上下文，renderer 也不重新猜测 role。强文本证据固定使用 Unicode 17.0.0
 `Scripts.txt` 的 Script 数据；Common、Inherited 与未分配码点不提供语言证据，也不依赖
 Android、JVM 或 JS 自带的 Unicode 表。
+同为 Common 的 U+2014 破折号与 U+2026 省略号按连续 source run 解析两侧最近的强脚本文本；
+连续数量只界定待判定的 source run，不参与中西角色选择。两侧冲突或无证据时使用段落语言，强制换行截断
+搜索。只有最终判为 `CjkPunctuation` 的 run 才能进入 CLREQ display 码点替换。
 
 ## 排版核心
 
@@ -206,6 +209,9 @@ TalkBack character-location 能力不属于当前静态正文路径。
 `platforms/web/client` 发布 ESM 包 `@tiqian/prose` 与 light-DOM `<tiqian-prose>`。服务器输出的
 HTML 先保持可读，TS runtime（`@tiqian/core` 宿主模块与 `@tiqian/ffi` 引擎）与字体就绪后按 viewport 距离逐段原子增强。原 `<p>`、链接、代码、强调、自定义
 inline 与 CSS 仍由宿主持有；引擎只写入断行和 spacing geometry。
+`strong-as-emphasis` lowering 先保留 source range，等整段文本完成空白投影后再通过 FFI 批量取得
+字体角色；不能在单个 DOM text node 上提前决定着重号或字重，否则跨节点的破折号、省略号会失去
+段落脚本上下文。
 
 同仓库的 `platforms/web/client/sveltekit` 与 `platforms/web/client/astro` 分别发布
 `@tiqian/sveltekit` 和 `@tiqian/astro`。它们只把框架的 SSR、静态构建、head 资产与客户端导航生命周期

--- a/docs/clreq-punctuation-audit.md
+++ b/docs/clreq-punctuation-audit.md
@@ -88,7 +88,9 @@ CLREQ 行首行尾禁则分四档（`KinsokuLevel`，命名对齐第六节原文
 两侧一致或只有一侧有证据时继承该侧；两侧冲突或都没有证据时按段落 locale 解析。强制换行会
 截断搜索（弯引号的配对模型允许引文跨行，其上下文扫描不以换行为界，两者是既定差异）。
 run 长度不参与字体角色判定；run 无论判为哪一侧都保持独立 cluster
-（`ContextualDashEllipsisRunSegmentation`），断行机会不因 Latin 合并消失。
+（`ContextualDashEllipsisRunSegmentation`），断行机会不因 Latin 合并消失。相邻等长的纯
+破折号 run 在中间内容全为词字符或空格时构成插入语对，按对外侧证据联合决议、插入内容
+不投票（`ParentheticalDashPairContext`）；间隔含句读或符号则各自独立。
 
 其余各归各：
 所有可打印 ASCII（U+0020–007E，含 `% . , : ; - / ~ | \` 等）是 typed Western intent →

--- a/docs/clreq-punctuation-audit.md
+++ b/docs/clreq-punctuation-audit.md
@@ -19,7 +19,9 @@ source "‧" -> display "·"
 source "•" -> display "·"
 ```
 
-这些是候选 display 替换，不是无条件保证。目标字体缺字、advance 或 ink 无法满足规范几何时，
+这些替换只是候选 display 方案，是否采用由上下文角色与字体几何共同决定。破折号或省略号的
+source run 必须先由上下文判为
+`CjkPunctuation`；判为西文时保留 source display。目标字体缺字、advance 或 ink 无法满足规范几何时，
 引擎会记录具名原因并回滚为 source text；Web 的两字破折号还需要 ADR 0039 规定的真实 face / glyph
 证据，不能只凭 Canvas 画出了正宽字符就宣称候选成立。
 
@@ -79,12 +81,19 @@ CLREQ 行首行尾禁则分四档（`KinsokuLevel`，命名对齐第六节原文
 
 ## 字体面归属（中西共用码点）
 
-字体**面**（Latin vs CJK）是码点问题，不是字形问题。中西真·共用码点只有
-弯引号 U+2018–201D。它们先建立嵌套配对，再按同一层级的双向外层脚本、外层引号、完整引文内容
-与段落 locale 依次解析；不能由紧邻字符或引文首字符单独决定。其余各归各：
+字体**面**（Latin vs CJK）先由源码与上下文决定，再进入字形选择。中西共用且需要上下文解析的
+码点包括弯引号 U+2018–201D、破折号 U+2014 与省略号 U+2026。弯引号先建立嵌套配对，再按
+同一层级的双向外层脚本、外层引号、完整引文内容与段落 locale 依次解析；不能由紧邻字符或
+引文首字符单独决定。破折号与省略号先形成连续 source run，再检查 run 两侧最近的强脚本文本：
+两侧一致或只有一侧有证据时继承该侧；两侧冲突或都没有证据时按段落 locale 解析。强制换行会
+截断搜索。run 长度不参与字体角色判定；后续 cluster 形成由最终 role 与 profile 决定。
+
+其余各归各：
 所有可打印 ASCII（U+0020–007E，含 `% . , : ; - / ~ | \` 等）是 typed Western intent →
-**Latin 面**；CJK 专有码点（`—` U+2014、`…` U+2026、`、`、全宽 `FF**`、`·`、`•`）→
-**CJK 面**。判定在 `CjkFontRoleClassifier`。
+**Latin 面**；CJK 专有码点（`、`、全宽 `FF**`、`·`、`•`，以及明确的推荐显示形式
+`⸺` / `⋯`）→ **CJK 面**。基础码点判定在 `CjkFontRoleClassifier`，弯引号与破折号/省略号
+分别由 `ContextualQuoteRoleResolver` 和 `ContextualDashEllipsisRoleResolution` 写回结构化
+role decision。
 
 历史 drift（已收回）：曾把 ASCII `- / ~` 误塞 `isCjkPunctuationCodePoint` 并给它们加
 `isLatinTechnicalPunctuation` 上下文补丁，其余 ASCII 标点漏到 `Unknown` → CJK 面，

--- a/docs/clreq-punctuation-audit.md
+++ b/docs/clreq-punctuation-audit.md
@@ -86,7 +86,9 @@ CLREQ 行首行尾禁则分四档（`KinsokuLevel`，命名对齐第六节原文
 同一层级的双向外层脚本、外层引号、完整引文内容与段落 locale 依次解析；不能由紧邻字符或
 引文首字符单独决定。破折号与省略号先形成连续 source run，再检查 run 两侧最近的强脚本文本：
 两侧一致或只有一侧有证据时继承该侧；两侧冲突或都没有证据时按段落 locale 解析。强制换行会
-截断搜索。run 长度不参与字体角色判定；后续 cluster 形成由最终 role 与 profile 决定。
+截断搜索（弯引号的配对模型允许引文跨行，其上下文扫描不以换行为界，两者是既定差异）。
+run 长度不参与字体角色判定；run 无论判为哪一侧都保持独立 cluster
+（`ContextualDashEllipsisRunSegmentation`），断行机会不因 Latin 合并消失。
 
 其余各归各：
 所有可打印 ASCII（U+0020–007E，含 `% . , : ; - / ~ | \` 等）是 typed Western intent →

--- a/engine/src/commonMain/kotlin/org/tiqian/clreq/ClreqProfile.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/clreq/ClreqProfile.kt
@@ -577,7 +577,7 @@ data class CjkPunctuationGlyphSubstitution(
 class ClreqPunctuationGlyphSubstitutor(
     private val policy: CjkPunctuationGlyphPolicy = CjkPunctuationGlyphPolicy.PreferClreqRecommendedCodepoints,
 ) {
-    fun substitute(sourceText: String): CjkPunctuationGlyphSubstitution {
+    internal fun substitute(sourceText: String): CjkPunctuationGlyphSubstitution {
         val displayText = when (policy) {
             CjkPunctuationGlyphPolicy.PreserveInput -> sourceText
             CjkPunctuationGlyphPolicy.PreferClreqRecommendedCodepoints,

--- a/engine/src/commonMain/kotlin/org/tiqian/core/UnicodeScriptEvidence.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/core/UnicodeScriptEvidence.kt
@@ -3,7 +3,7 @@ package org.tiqian.core
 /**
  * Stable Unicode Script evidence for language-sensitive Common punctuation.
  * Common, Inherited, and unassigned scalars are neutral: punctuation, spaces,
- * and ASCII digits do not get to decide the language of surrounding quotes.
+ * and ASCII digits do not get to decide the language of surrounding marks.
  */
 enum class UnicodeScriptEvidence {
     Neutral,

--- a/engine/src/commonMain/kotlin/org/tiqian/font/FontPolicy.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/font/FontPolicy.kt
@@ -69,8 +69,9 @@ class CjkFontRoleClassifier : FontRoleClassifier {
         val firstCodePoint = text.codePointAtCompat(range.start)
         return when {
             firstCodePoint.isCjkCodePoint() -> FontRole.CjkText
-            // The ONLY shared CJK/Western code points are the curly quotes — resolved by
-            // context. Everything else is native: typed ASCII → Latin, CJK code points → CJK.
+            // Shared curly quotes are provisionally resolved here and structurally overridden
+            // by QuotePairAnalyzer. U+2014/U+2026 default to CJK here, then the paragraph-level
+            // ContextualDashEllipsisRoleResolution applies full surrounding-script evidence.
             firstCodePoint.isLatinCurlyQuote(text, range) -> FontRole.LatinText
             firstCodePoint.isCjkPunctuationCodePoint() -> FontRole.CjkPunctuation
             firstCodePoint.isTypedAsciiLatin() -> FontRole.LatinText
@@ -137,9 +138,10 @@ class CjkFontRoleClassifier : FontRoleClassifier {
 
     /**
      * All printable ASCII (U+0020..U+007E) is typed-Latin intent → [FontRole.LatinText].
-     * The ONLY CJK/Western shared code points are the curly quotes (U+2018–201D), resolved
-     * by context in [isLatinCurlyQuote]; genuinely-CJK code points (—, …, 、, fullwidth FF**)
-     * are caught by [isCjkPunctuationCodePoint] before this. So an ASCII `%` / `.` / `-` / `/`
+     * Curly quotes (U+2018–201D) are provisionally resolved in [isLatinCurlyQuote], while
+     * paragraph analysis owns the final context decision for them and for U+2014/U+2026.
+     * CJK punctuation defaults (including the base role for contextual `—` / `…`) are caught
+     * by [isCjkPunctuationCodePoint] before this. So an ASCII `%` / `.` / `-` / `/`
      * renders Western and aggregates with adjacent Latin instead of landing on the CJK face
      * (ADR 0029: ASCII `-`/`/` is an English hyphen, not a CJK 连接号). U+0020 SPACE joins the
      * Latin run per ADR 0009 (advance later adjusted by `ClreqProfile.autoSpace` at boundaries).

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/ClusterRoleResolution.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/ClusterRoleResolution.kt
@@ -219,7 +219,16 @@ internal fun clusterRoleRanges(
                 .minOrNull()
                 ?: graphemeEnd
         } else if (role == FontRole.LatinText) {
-            if (attachedAsciiPointMark) {
+            if (codePoint.isContextualDashEllipsisCodePoint()) {
+                // `ContextualDashEllipsisRunSegmentation`: a mark run resolved to the
+                // Latin face still forms its own cluster, keeping the code-point
+                // line-break classes' opportunities at the run boundary.
+                while (index < text.length && index !in spanBoundaries) {
+                    val nextCodePoint = text.codePointAtCompat(index)
+                    if (nextCodePoint != codePoint) break
+                    index += nextCodePoint.charCount()
+                }
+            } else if (attachedAsciiPointMark) {
                 // `AttachedAsciiPointMarkSegmentation`: keep the leading
                 // point-mark run independent from following Latin text so
                 // kinsoku never has to move an entire `,anyway` token.
@@ -236,6 +245,7 @@ internal fun clusterRoleRanges(
                     val nextCharCount = nextCodePoint.charCount()
                     val nextRange = TextRange(index, index + nextCharCount)
                     if (
+                        nextCodePoint.isContextualDashEllipsisCodePoint() ||
                         classifier.classify(text, nextRange, context) != FontRole.LatinText ||
                         text.emojiRolePromotionReason(index, text.length) != null
                     ) {
@@ -315,6 +325,9 @@ private fun Int.isCombiningMarkCodePoint(): Boolean =
 
 private fun Int.isAsciiPointMarkCodePoint(): Boolean =
     this in 0..0xFFFF && ClreqPunctuationPolicies.isAsciiPointMark(toChar())
+
+private fun Int.isContextualDashEllipsisCodePoint(): Boolean =
+    this == 0x2014 || this == 0x2026
 
 /**
  * `UnicodeEmojiSequenceRolePromotion`: promotes a text-default scalar to the Emoji fallback

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/ClusterRoleResolution.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/ClusterRoleResolution.kt
@@ -222,11 +222,14 @@ internal fun clusterRoleRanges(
             if (codePoint.isContextualDashEllipsisCodePoint()) {
                 // `ContextualDashEllipsisRunSegmentation`: a mark run resolved to the
                 // Latin face still forms its own cluster, keeping the code-point
-                // line-break classes' opportunities at the run boundary.
-                while (index < text.length && index !in spanBoundaries) {
-                    val nextCodePoint = text.codePointAtCompat(index)
-                    if (nextCodePoint != codePoint) break
-                    index += nextCodePoint.charCount()
+                // line-break classes' opportunities at the run boundary. The same
+                // profile coalesce set gates repeats on both faces.
+                if (codePoint in coalesceSet) {
+                    while (index < text.length && index !in spanBoundaries) {
+                        val nextCodePoint = text.codePointAtCompat(index)
+                        if (nextCodePoint != codePoint) break
+                        index += nextCodePoint.charCount()
+                    }
                 }
             } else if (attachedAsciiPointMark) {
                 // `AttachedAsciiPointMarkSegmentation`: keep the leading

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolver.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolver.kt
@@ -5,6 +5,7 @@ import org.tiqian.core.TextRange
 import org.tiqian.core.UnicodeEastAsianSpacing
 import org.tiqian.core.UnicodeScriptEvidence
 import org.tiqian.core.UnicodeScriptEvidenceClassifier
+import org.tiqian.core.UnicodeWordCharacter
 import org.tiqian.font.FontRole
 import org.tiqian.font.FontRoleClassifier
 import org.tiqian.font.FontRoleContext
@@ -26,6 +27,13 @@ internal data class DashEllipsisRoleDecision(
  * Conflicting or absent evidence falls back to the paragraph language. A
  * mandatory break is a hard context boundary, so an otherwise empty source
  * line cannot borrow the script of a neighbouring line.
+ *
+ * `ParentheticalDashPairContext`: two adjacent equal-length pure U+2014 runs
+ * whose separating content is only word characters and ASCII spaces form one
+ * parenthetical insertion and resolve jointly from the text outside it. The
+ * inserted content never votes, so `想Jessica——Jessica是他的前女友——睡不着`
+ * keeps both dashes on one face. Any other separating character keeps the
+ * runs independent; ellipsis runs never pair.
  */
 internal class ContextualDashEllipsisRoleResolver {
     fun resolve(
@@ -33,55 +41,119 @@ internal class ContextualDashEllipsisRoleResolver {
         context: FontRoleContext = FontRoleContext(),
     ): List<DashEllipsisRoleDecision> {
         if (text.none { it.isContextualDashOrEllipsis() }) return emptyList()
-        val decisions = mutableListOf<DashEllipsisRoleDecision>()
         val strongScriptContext = StrongScriptContextIndex(text)
-        var index = 0
-        while (index < text.length) {
-            if (!text[index].isContextualDashOrEllipsis()) {
-                index += text.codePointLengthAt(index)
-                continue
-            }
-
-            val start = index
-            while (index < text.length && text[index].isContextualDashOrEllipsis()) {
-                index += 1
-            }
-            val range = TextRange(start, index)
-            val leftRole = strongScriptContext.leftOf(start)
-            val rightRole = strongScriptContext.rightOf(index)
-            val resolution = when {
-                leftRole != null && rightRole == leftRole -> Resolution(
-                    role = leftRole,
-                    source = "DashEllipsisSurroundingScriptContext",
-                    reason = "matching-surrounding-script",
-                )
-                leftRole != null && rightRole == null -> Resolution(
-                    role = leftRole,
-                    source = "DashEllipsisSurroundingScriptContext",
-                    reason = "only-left-strong-script",
-                )
-                rightRole != null && leftRole == null -> Resolution(
-                    role = rightRole,
-                    source = "DashEllipsisSurroundingScriptContext",
-                    reason = "only-right-strong-script",
-                )
-                else -> paragraphLanguageResolution(
-                    context = context,
-                    reason = if (leftRole != null && rightRole != null) {
-                        "conflicting-surrounding-script"
-                    } else {
-                        "no-strong-script-context"
-                    },
-                )
-            }
-            decisions += DashEllipsisRoleDecision(
+        val runs = collectRuns(text)
+        val pairResolutions = resolveParentheticalPairs(text, runs, strongScriptContext, context)
+        return runs.map { range ->
+            val resolution = pairResolutions[range]
+                ?: resolveSingleRun(range, strongScriptContext, context)
+            DashEllipsisRoleDecision(
                 range = range,
                 role = resolution.role,
                 source = resolution.source,
                 reason = resolution.reason,
             )
         }
-        return decisions
+    }
+
+    private fun collectRuns(text: String): List<TextRange> {
+        val runs = mutableListOf<TextRange>()
+        var index = 0
+        while (index < text.length) {
+            if (!text[index].isContextualDashOrEllipsis()) {
+                index += text.codePointLengthAt(index)
+                continue
+            }
+            val start = index
+            while (index < text.length && text[index].isContextualDashOrEllipsis()) {
+                index += 1
+            }
+            runs += TextRange(start, index)
+        }
+        return runs
+    }
+
+    private fun resolveSingleRun(
+        range: TextRange,
+        strongScriptContext: StrongScriptContextIndex,
+        context: FontRoleContext,
+    ): Resolution {
+        val leftRole = strongScriptContext.leftOf(range.start)
+        val rightRole = strongScriptContext.rightOf(range.end)
+        return when {
+            leftRole != null && rightRole == leftRole -> Resolution(
+                role = leftRole,
+                source = "DashEllipsisSurroundingScriptContext",
+                reason = "matching-surrounding-script",
+            )
+            leftRole != null && rightRole == null -> Resolution(
+                role = leftRole,
+                source = "DashEllipsisSurroundingScriptContext",
+                reason = "only-left-strong-script",
+            )
+            rightRole != null && leftRole == null -> Resolution(
+                role = rightRole,
+                source = "DashEllipsisSurroundingScriptContext",
+                reason = "only-right-strong-script",
+            )
+            else -> paragraphLanguageResolution(
+                context = context,
+                reason = if (leftRole != null && rightRole != null) {
+                    "conflicting-surrounding-script"
+                } else {
+                    "no-strong-script-context"
+                },
+            )
+        }
+    }
+
+    private fun resolveParentheticalPairs(
+        text: String,
+        runs: List<TextRange>,
+        strongScriptContext: StrongScriptContextIndex,
+        context: FontRoleContext,
+    ): Map<TextRange, Resolution> {
+        val resolutions = mutableMapOf<TextRange, Resolution>()
+        var index = 0
+        while (index + 1 < runs.size) {
+            val first = runs[index]
+            val second = runs[index + 1]
+            if (!text.isParentheticalDashPair(first, second)) {
+                index += 1
+                continue
+            }
+            val leftRole = strongScriptContext.leftOf(first.start)
+            val rightRole = strongScriptContext.rightOf(second.end)
+            val resolution = when {
+                leftRole != null && rightRole == leftRole -> Resolution(
+                    role = leftRole,
+                    source = "ParentheticalDashPairContext",
+                    reason = "matching-outer-script",
+                )
+                leftRole != null && rightRole == null -> Resolution(
+                    role = leftRole,
+                    source = "ParentheticalDashPairContext",
+                    reason = "only-left-outer-script",
+                )
+                rightRole != null && leftRole == null -> Resolution(
+                    role = rightRole,
+                    source = "ParentheticalDashPairContext",
+                    reason = "only-right-outer-script",
+                )
+                else -> paragraphLanguageResolution(
+                    context = context,
+                    reason = if (leftRole != null && rightRole != null) {
+                        "parenthetical-pair-conflicting-outer-script"
+                    } else {
+                        "parenthetical-pair-no-outer-context"
+                    },
+                )
+            }
+            resolutions[first] = resolution
+            resolutions[second] = resolution
+            index += 2
+        }
+        return resolutions
     }
 
     private fun paragraphLanguageResolution(
@@ -153,6 +225,25 @@ internal fun List<DashEllipsisRoleDecision>.toRoleOverrideInfos(
 }
 
 private fun Char.isContextualDashOrEllipsis(): Boolean = this == '\u2014' || this == '\u2026'
+
+private fun String.isParentheticalDashPair(first: TextRange, second: TextRange): Boolean {
+    if (!isPureDashRun(first) || !isPureDashRun(second)) return false
+    if (first.end - first.start != second.end - second.start) return false
+    var index = first.end
+    while (index < second.start) {
+        val codePoint = codePointAtCompat(index)
+        if (codePoint != 0x20 && !UnicodeWordCharacter.contains(codePoint)) return false
+        index += codePoint.charCount()
+    }
+    return true
+}
+
+private fun String.isPureDashRun(range: TextRange): Boolean {
+    for (index in range.start until range.end) {
+        if (this[index] != '\u2014') return false
+    }
+    return true
+}
 
 /**
  * `StrongScriptContextIndex` records the nearest strong script at every UTF-16

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolver.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolver.kt
@@ -1,0 +1,231 @@
+package org.tiqian.layout
+
+import org.tiqian.core.RoleOverrideInfo
+import org.tiqian.core.TextRange
+import org.tiqian.core.UnicodeEastAsianSpacing
+import org.tiqian.core.UnicodeScriptEvidence
+import org.tiqian.core.UnicodeScriptEvidenceClassifier
+import org.tiqian.font.FontRole
+import org.tiqian.font.FontRoleClassifier
+import org.tiqian.font.FontRoleContext
+import org.tiqian.linebreak.isMandatoryBreakCodePoint
+
+internal data class DashEllipsisRoleDecision(
+    val range: TextRange,
+    val role: FontRole,
+    val source: String,
+    val reason: String,
+)
+
+/**
+ * `ContextualDashEllipsisRoleResolution` resolves U+2014 EM DASH and U+2026
+ * HORIZONTAL ELLIPSIS from surrounding strong-script text. The number of
+ * repeated marks only defines the source run; it never decides its language.
+ *
+ * Matching strong evidence on both sides, or the only available side, wins.
+ * Conflicting or absent evidence falls back to the paragraph language. A
+ * mandatory break is a hard context boundary, so an otherwise empty source
+ * line cannot borrow the script of a neighbouring line.
+ */
+internal class ContextualDashEllipsisRoleResolver {
+    fun resolve(
+        text: String,
+        context: FontRoleContext = FontRoleContext(),
+    ): List<DashEllipsisRoleDecision> {
+        if (text.none { it.isContextualDashOrEllipsis() }) return emptyList()
+        val decisions = mutableListOf<DashEllipsisRoleDecision>()
+        val strongScriptContext = StrongScriptContextIndex(text)
+        var index = 0
+        while (index < text.length) {
+            if (!text[index].isContextualDashOrEllipsis()) {
+                index += text.codePointLengthAt(index)
+                continue
+            }
+
+            val start = index
+            while (index < text.length && text[index].isContextualDashOrEllipsis()) {
+                index += 1
+            }
+            val range = TextRange(start, index)
+            val leftRole = strongScriptContext.leftOf(start)
+            val rightRole = strongScriptContext.rightOf(index)
+            val resolution = when {
+                leftRole != null && rightRole == leftRole -> Resolution(
+                    role = leftRole,
+                    source = "DashEllipsisSurroundingScriptContext",
+                    reason = "matching-surrounding-script",
+                )
+                leftRole != null && rightRole == null -> Resolution(
+                    role = leftRole,
+                    source = "DashEllipsisSurroundingScriptContext",
+                    reason = "only-left-strong-script",
+                )
+                rightRole != null && leftRole == null -> Resolution(
+                    role = rightRole,
+                    source = "DashEllipsisSurroundingScriptContext",
+                    reason = "only-right-strong-script",
+                )
+                else -> paragraphLanguageResolution(
+                    context = context,
+                    reason = if (leftRole != null && rightRole != null) {
+                        "conflicting-surrounding-script"
+                    } else {
+                        "no-strong-script-context"
+                    },
+                )
+            }
+            decisions += DashEllipsisRoleDecision(
+                range = range,
+                role = resolution.role,
+                source = resolution.source,
+                reason = resolution.reason,
+            )
+        }
+        return decisions
+    }
+
+    private fun paragraphLanguageResolution(
+        context: FontRoleContext,
+        reason: String,
+    ): Resolution = Resolution(
+        role = if (UnicodeEastAsianSpacing.isChineseLanguageContext(context.locale)) {
+            FontRole.CjkPunctuation
+        } else {
+            FontRole.LatinText
+        },
+        source = "ParagraphLanguageDashEllipsisContext",
+        reason = "$reason; paragraph-language=${context.locale}",
+    )
+
+    private data class Resolution(
+        val role: FontRole,
+        val source: String,
+        val reason: String,
+    )
+}
+
+internal class ContextualDashEllipsisAwareFontRoleClassifier(
+    private val delegate: FontRoleClassifier,
+    decisions: List<DashEllipsisRoleDecision>,
+) : FontRoleClassifier {
+    private val roleByIndex: Map<Int, FontRole> = buildMap {
+        decisions.forEach { decision ->
+            for (index in decision.range.start until decision.range.end) {
+                put(index, decision.role)
+            }
+        }
+    }
+
+    override fun classify(text: String, range: TextRange, context: FontRoleContext): FontRole =
+        roleByIndex[range.start] ?: delegate.classify(text, range, context)
+}
+
+/**
+ * Resolves contextual U+2014 and U+2026 roles for callers that classify several ranges from the
+ * same complete paragraph outside the layout pipeline, such as markdown lowering bridges.
+ */
+fun FontRoleClassifier.withContextualDashEllipsisRoles(
+    text: String,
+    context: FontRoleContext = FontRoleContext(),
+): FontRoleClassifier {
+    val decisions = ContextualDashEllipsisRoleResolver().resolve(text, context)
+    return if (decisions.isEmpty()) {
+        this
+    } else {
+        ContextualDashEllipsisAwareFontRoleClassifier(this, decisions)
+    }
+}
+
+internal fun List<DashEllipsisRoleDecision>.toRoleOverrideInfos(
+    text: String,
+    baseClassifier: FontRoleClassifier,
+    context: FontRoleContext,
+): List<RoleOverrideInfo> = map { decision ->
+    val firstCodePointRange = TextRange(decision.range.start, decision.range.start + 1)
+    RoleOverrideInfo(
+        range = decision.range,
+        sourceText = text.substring(decision.range.start, decision.range.end),
+        originalRole = baseClassifier.classify(text, firstCodePointRange, context).name,
+        overriddenRole = decision.role.name,
+        source = decision.source,
+        reason = decision.reason,
+    )
+}
+
+private fun Char.isContextualDashOrEllipsis(): Boolean = this == '\u2014' || this == '\u2026'
+
+/**
+ * `StrongScriptContextIndex` records the nearest strong script at every UTF-16
+ * boundary in two linear passes. Mandatory breaks reset both directions, so a
+ * contextual punctuation run cannot borrow evidence from another source line.
+ */
+private class StrongScriptContextIndex(text: String) {
+    private val leftRoleBeforeBoundary = arrayOfNulls<FontRole>(text.length + 1)
+    private val rightRoleFromBoundary = arrayOfNulls<FontRole>(text.length + 1)
+
+    init {
+        var currentRole: FontRole? = null
+        var scalarStart = 0
+        leftRoleBeforeBoundary[0] = null
+        while (scalarStart < text.length) {
+            val codePoint = text.codePointAtCompat(scalarStart)
+            val scalarEnd = scalarStart + codePoint.charCount()
+            currentRole = codePoint.nextStrongScriptRole(currentRole)
+            for (boundary in scalarStart + 1..scalarEnd) {
+                leftRoleBeforeBoundary[boundary] = currentRole
+            }
+            scalarStart = scalarEnd
+        }
+
+        currentRole = null
+        var scalarEnd = text.length
+        rightRoleFromBoundary[text.length] = null
+        while (scalarEnd > 0) {
+            scalarStart = text.scalarStartBefore(scalarEnd)
+            val codePoint = text.codePointAtCompat(scalarStart)
+            currentRole = codePoint.nextStrongScriptRole(currentRole)
+            for (boundary in scalarStart until scalarEnd) {
+                rightRoleFromBoundary[boundary] = currentRole
+            }
+            scalarEnd = scalarStart
+        }
+    }
+
+    fun leftOf(boundary: Int): FontRole? = leftRoleBeforeBoundary[boundary]
+
+    fun rightOf(boundary: Int): FontRole? = rightRoleFromBoundary[boundary]
+}
+
+private fun Int.nextStrongScriptRole(currentRole: FontRole?): FontRole? {
+    if (isMandatoryBreakCodePoint(this)) return null
+    return when (UnicodeScriptEvidenceClassifier.classify(this)) {
+        UnicodeScriptEvidence.EastAsian -> FontRole.CjkPunctuation
+        UnicodeScriptEvidence.Other -> FontRole.LatinText
+        UnicodeScriptEvidence.Neutral -> currentRole
+    }
+}
+
+private fun String.scalarStartBefore(endExclusive: Int): Int {
+    val lastIndex = endExclusive - 1
+    return if (
+        this[lastIndex].code in 0xDC00..0xDFFF &&
+        lastIndex > 0 &&
+        this[lastIndex - 1].code in 0xD800..0xDBFF
+    ) {
+        lastIndex - 1
+    } else {
+        lastIndex
+    }
+}
+
+private fun String.codePointAtCompat(index: Int): Int {
+    val high = this[index].code
+    if (high !in 0xD800..0xDBFF || index + 1 >= length) return high
+    val low = this[index + 1].code
+    if (low !in 0xDC00..0xDFFF) return high
+    return 0x10000 + ((high - 0xD800) shl 10) + (low - 0xDC00)
+}
+
+private fun String.codePointLengthAt(index: Int): Int = codePointAtCompat(index).charCount()
+
+private fun Int.charCount(): Int = if (this > 0xFFFF) 2 else 1

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/ContextualPunctuationDisplaySubstitution.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/ContextualPunctuationDisplaySubstitution.kt
@@ -1,0 +1,27 @@
+package org.tiqian.layout
+
+import org.tiqian.clreq.CjkPunctuationGlyphSubstitution
+import org.tiqian.clreq.ClreqPunctuationGlyphSubstitutor
+import org.tiqian.font.FontRole
+
+/**
+ * `CjkRoleGatedDisplaySubstitution` keeps CLREQ display-codepoint replacement
+ * downstream of contextual font-role resolution. A dash or ellipsis resolved
+ * as Western must retain its source code point even when a style boundary
+ * leaves that punctuation in a standalone shaping segment.
+ */
+internal fun ClreqPunctuationGlyphSubstitutor.substituteForRole(
+    sourceText: String,
+    role: FontRole,
+): CjkPunctuationGlyphSubstitution {
+    val candidate = substitute(sourceText)
+    return if (role == FontRole.CjkPunctuation || candidate.displayText == sourceText) {
+        candidate
+    } else {
+        CjkPunctuationGlyphSubstitution(
+            sourceText = sourceText,
+            displayText = sourceText,
+            reason = "CjkRoleGatedDisplaySubstitution:preserve-role-$role",
+        )
+    }
+}

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/LayoutDebugAssembly.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/LayoutDebugAssembly.kt
@@ -157,7 +157,7 @@ internal fun ExplainableStubParagraphLayoutEngine.buildLayoutDebugInfo(stage: La
 LayoutDebugInfo(
             fontDecisions = fontDecisions.map { decision ->
                 val clusterText = text.substring(decision.range.start, decision.range.end)
-                val substitution = punctuationGlyphSubstitutor.substitute(clusterText)
+                val substitution = punctuationGlyphSubstitutor.substituteForRole(clusterText, decision.role)
                 val rollbackCause = substitutionRollbacks.entries.firstOrNull { it.key.isInside(decision.range) }?.value
                 FontDecisionInfo(
                     range = decision.range,

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/ParagraphShapingStage.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/ParagraphShapingStage.kt
@@ -162,7 +162,7 @@ internal fun ExplainableStubParagraphLayoutEngine.shapeParagraph(
         val cached = segmentShapingCache[segmentRange]
         if (cached != null) return cached
         val sourceText = text.substring(segmentRange.start, segmentRange.end)
-        val substitution = punctuationGlyphSubstitutor.substitute(sourceText)
+        val substitution = punctuationGlyphSubstitutor.substituteForRole(sourceText, decision.role)
         val baseSegmentStyle = styleAt(segmentRange.start)
         val segmentStyle = if (decision.role == FontRole.LatinText && emphasisItalicAt(segmentRange.start)) {
             baseSegmentStyle.copy(italic = true)

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/QuotePairAnalyzer.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/QuotePairAnalyzer.kt
@@ -171,3 +171,22 @@ class QuotePairAwareFontRoleClassifier(
     override fun classify(text: String, range: TextRange, context: FontRoleContext): FontRole =
         quoteRoles[range.start] ?: delegate.classify(text, range, context)
 }
+
+/**
+ * Resolves contextual curly-quote roles for callers that classify several ranges from the
+ * same complete paragraph outside the layout pipeline, mirroring the pipeline assembly in
+ * `prepareWidthIndependentAnnotation`. Chain with [withContextualDashEllipsisRoles] in the
+ * same base-to-outermost order the pipeline uses.
+ */
+fun FontRoleClassifier.withContextualQuoteRoles(
+    text: String,
+    context: FontRoleContext = FontRoleContext(),
+): FontRoleClassifier {
+    val analyzer = QuotePairAnalyzer()
+    val decisions = analyzer.classifyQuoteRoles(text, analyzer.analyze(text), context)
+    return if (decisions.isEmpty()) {
+        this
+    } else {
+        QuotePairAwareFontRoleClassifier(this, decisions.associate { it.index to it.role })
+    }
+}

--- a/engine/src/commonMain/kotlin/org/tiqian/layout/WidthIndependentAnnotationCache.kt
+++ b/engine/src/commonMain/kotlin/org/tiqian/layout/WidthIndependentAnnotationCache.kt
@@ -287,10 +287,21 @@ internal fun ExplainableStubParagraphLayoutEngine.prepareWidthIndependentAnnotat
         baseClassifier = fontRoleClassifier,
         context = context,
     )
-    val effectiveClassifier: FontRoleClassifier = if (quoteRoleOverrides.isNotEmpty()) {
+    val quoteAwareClassifier: FontRoleClassifier = if (quoteRoleOverrides.isNotEmpty()) {
         QuotePairAwareFontRoleClassifier(fontRoleClassifier, quoteRoleOverrides)
     } else {
         fontRoleClassifier
+    }
+    val dashEllipsisRoleDecisions = ContextualDashEllipsisRoleResolver().resolve(text, context)
+    val dashEllipsisRoleOverrideInfos = dashEllipsisRoleDecisions.toRoleOverrideInfos(
+        text = text,
+        baseClassifier = quoteAwareClassifier,
+        context = context,
+    )
+    val effectiveClassifier: FontRoleClassifier = if (dashEllipsisRoleDecisions.isNotEmpty()) {
+        ContextualDashEllipsisAwareFontRoleClassifier(quoteAwareClassifier, dashEllipsisRoleDecisions)
+    } else {
+        quoteAwareClassifier
     }
 
     val clusterRanges = clusterRoleRanges(
@@ -302,7 +313,11 @@ internal fun ExplainableStubParagraphLayoutEngine.prepareWidthIndependentAnnotat
         emojiShapingBoundaries,
         input.inlineObjects.associateBy { it.range.start },
     )
-    val roleOverrideInfos = (quoteRoleOverrideInfos + clusterRanges.mapNotNull { it.roleOverride })
+    val roleOverrideInfos = (
+        quoteRoleOverrideInfos +
+            dashEllipsisRoleOverrideInfos +
+            clusterRanges.mapNotNull { it.roleOverride }
+    )
         .sortedBy { it.range.start }
     val shapeableRanges = clusterRanges.filterNot {
         it.mandatoryBreak || it.zeroWidthSoftBreak || inlineObjectByRange.containsKey(it.range)

--- a/engine/src/commonTest/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolverTest.kt
+++ b/engine/src/commonTest/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolverTest.kt
@@ -1,0 +1,165 @@
+package org.tiqian.layout
+
+import org.tiqian.core.LayoutConstraints
+import org.tiqian.core.LayoutInput
+import org.tiqian.core.LayoutResult
+import org.tiqian.core.ParagraphStyle
+import org.tiqian.core.TextStyle
+import org.tiqian.core.TiqianTextContent
+import org.tiqian.core.ic
+import org.tiqian.font.FontRole
+import org.tiqian.font.FontRoleContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ContextualDashEllipsisRoleResolverTest {
+    private val resolver = ContextualDashEllipsisRoleResolver()
+
+    @Test
+    fun resolvesBySurroundingScriptRatherThanMarkCount() {
+        val cases = listOf(
+            RoleCase("English — next", '—', FontRole.LatinText),
+            RoleCase("— English", '—', FontRole.LatinText),
+            RoleCase("A——B", '—', FontRole.LatinText),
+            RoleCase("Wait…what", '…', FontRole.LatinText),
+            RoleCase("Wait……what", '…', FontRole.LatinText),
+            RoleCase("中文—下句", '—', FontRole.CjkPunctuation),
+            RoleCase("中文——下句", '—', FontRole.CjkPunctuation),
+            RoleCase("中文—123", '—', FontRole.CjkPunctuation),
+            RoleCase("123—English", '—', FontRole.LatinText),
+            RoleCase("中文……", '…', FontRole.CjkPunctuation),
+            RoleCase("等等…真的", '…', FontRole.CjkPunctuation),
+            RoleCase("等等……真的", '…', FontRole.CjkPunctuation),
+        )
+
+        cases.forEach { case ->
+            val decision = resolver.resolve(case.text).single()
+            assertEquals(case.role, decision.role, case.text)
+            assertEquals(case.text.indexOf(case.mark), decision.range.start, case.text)
+            assertEquals(case.text.lastIndexOf(case.mark) + 1, decision.range.end, case.text)
+            assertEquals("DashEllipsisSurroundingScriptContext", decision.source, case.text)
+        }
+    }
+
+    @Test
+    fun conflictingOrAbsentScriptFallsBackToParagraphLanguage() {
+        for ((locale, role) in listOf("zh-Hans" to FontRole.CjkPunctuation, "en-US" to FontRole.LatinText)) {
+            val conflicting = resolver.resolve("中文—English", FontRoleContext(locale = locale)).single()
+            val isolated = resolver.resolve("…", FontRoleContext(locale = locale)).single()
+            assertEquals(role, conflicting.role, locale)
+            assertEquals(role, isolated.role, locale)
+            assertEquals("ParagraphLanguageDashEllipsisContext", conflicting.source, locale)
+            assertEquals("ParagraphLanguageDashEllipsisContext", isolated.source, locale)
+        }
+    }
+
+    @Test
+    fun decisionReasonNamesTheEvidenceShape() {
+        assertEquals("matching-surrounding-script", resolver.resolve("A—B").single().reason)
+        assertEquals("only-left-strong-script", resolver.resolve("中文……").single().reason)
+        assertEquals("only-right-strong-script", resolver.resolve("— English").single().reason)
+    }
+
+    @Test
+    fun mandatoryBreakStopsContextSearch() {
+        val decision = resolver.resolve("—\nEnglish", FontRoleContext(locale = "zh-Hans")).single()
+        assertEquals(FontRole.CjkPunctuation, decision.role)
+        assertEquals("ParagraphLanguageDashEllipsisContext", decision.source)
+        assertTrue(decision.reason.startsWith("no-strong-script-context"), decision.reason)
+    }
+
+    @Test
+    fun linearContextIndexPreservesSupplementaryScriptEvidence() {
+        val eastAsian = resolver.resolve("\uD840\uDC00—123").single()
+        val other = resolver.resolve("123—\uD801\uDC00").single()
+
+        assertEquals(FontRole.CjkPunctuation, eastAsian.role)
+        assertEquals(FontRole.LatinText, other.role)
+    }
+
+    @Test
+    fun resolvesManyNeutralSeparatedRunsFromOneParagraphIndex() {
+        val text = buildString {
+            append('A')
+            repeat(2_048) { append(" — ") }
+            append('B')
+        }
+
+        val decisions = resolver.resolve(text, FontRoleContext(locale = "zh-Hans"))
+
+        assertEquals(2_048, decisions.size)
+        assertTrue(decisions.all { it.role == FontRole.LatinText })
+    }
+
+    private data class RoleCase(
+        val text: String,
+        val mark: Char,
+        val role: FontRole,
+    )
+}
+
+class ContextualDashEllipsisLayoutTest {
+    private val engine = ExplainableStubParagraphLayoutEngine()
+
+    @Test
+    fun westernContextKeepsDashAndEllipsisOnLatinFaceAndPreservesSourceDisplay() {
+        val text = "English — next; ellipsis… / slash. A——B; Wait……what?"
+        val result = layout(text)
+
+        for (markIndex in text.indices.filter { text[it] == '—' || text[it] == '…' }) {
+            val decision = result.fontDecisionAt(markIndex)
+            assertEquals(FontRole.LatinText.name, decision.role, "index=$markIndex $decision")
+            assertEquals(decision.sourceText, decision.displayText, "index=$markIndex $decision")
+        }
+        assertTrue(result.debug.punctuationDecisions.none { it.char == '—' || it.char == '…' })
+        assertTrue(
+            result.debug.roleOverrides
+                .filter { it.sourceText.any { char -> char == '—' || char == '…' } }
+                .all { it.source == "DashEllipsisSurroundingScriptContext" },
+            result.debug.roleOverrides.toString(),
+        )
+    }
+
+    @Test
+    fun cjkContextKeepsClreqDisplaySubstitutionIndependentOfMarkCount() {
+        val text = "中—文，等…真；中文——下句，省略号……。"
+        val result = layout(text)
+
+        assertEquals("—", result.fontDecisionAt(text.indexOf('—')).displayText)
+        assertEquals("⋯", result.fontDecisionAt(text.indexOf('…')).displayText)
+        assertEquals("⸺", result.fontDecisionAt(text.indexOf("——")).displayText)
+        assertEquals("⋯⋯", result.fontDecisionAt(text.indexOf("……")).displayText)
+        for (markIndex in text.indices.filter { text[it] == '—' || text[it] == '…' }) {
+            assertEquals(FontRole.CjkPunctuation.name, result.fontDecisionAt(markIndex).role)
+        }
+    }
+
+    @Test
+    fun standaloneWesternEllipsisCannotBeRewrittenByTheSubstitutor() {
+        val result = layout("…", locale = "en-US")
+        val decision = result.debug.fontDecisions.single()
+
+        assertEquals(FontRole.LatinText.name, decision.role)
+        assertEquals("…", decision.sourceText)
+        assertEquals("…", decision.displayText)
+        assertEquals(
+            "CjkRoleGatedDisplaySubstitution:preserve-role-LatinText",
+            decision.substitutionReason,
+        )
+        assertEquals("…", result.clusters.single().displayText)
+    }
+
+    private fun layout(text: String, locale: String = "zh-Hans"): LayoutResult = engine.layout(
+        LayoutInput(
+            content = TiqianTextContent(text),
+            textStyle = TextStyle(locale = locale),
+            paragraphStyle = ParagraphStyle(firstLineIndent = 0.ic),
+            constraints = LayoutConstraints(maxWidth = 1000f),
+        ),
+    )
+
+    private fun LayoutResult.fontDecisionAt(index: Int) = debug.fontDecisions.single { decision ->
+        index >= decision.range.start && index < decision.range.end
+    }
+}

--- a/engine/src/commonTest/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolverTest.kt
+++ b/engine/src/commonTest/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolverTest.kt
@@ -112,6 +112,10 @@ class ContextualDashEllipsisLayoutTest {
             assertEquals(FontRole.LatinText.name, decision.role, "index=$markIndex $decision")
             assertEquals(decision.sourceText, decision.displayText, "index=$markIndex $decision")
         }
+        // ContextualDashEllipsisRunSegmentation: the Latin-resolved runs stay their
+        // own clusters, keeping break opportunities at the run boundaries.
+        assertEquals("——", result.fontDecisionAt(text.indexOf("——")).sourceText)
+        assertEquals("……", result.fontDecisionAt(text.indexOf("……")).sourceText)
         assertTrue(result.debug.punctuationDecisions.none { it.char == '—' || it.char == '…' })
         assertTrue(
             result.debug.roleOverrides

--- a/engine/src/commonTest/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolverTest.kt
+++ b/engine/src/commonTest/kotlin/org/tiqian/layout/ContextualDashEllipsisRoleResolverTest.kt
@@ -92,6 +92,97 @@ class ContextualDashEllipsisRoleResolverTest {
         assertTrue(decisions.all { it.role == FontRole.LatinText })
     }
 
+    @Test
+    fun pairsParentheticalDashesAcrossInsertedContent() {
+        val decisions = resolver.resolve(
+            "他彻夜想Jessica——Jessica是他的前女友——睡不着觉",
+            FontRoleContext(locale = "zh-Hans"),
+        )
+
+        assertEquals(2, decisions.size)
+        assertTrue(
+            decisions.all {
+                it.role == FontRole.CjkPunctuation &&
+                    it.source == "ParagraphLanguageDashEllipsisContext" &&
+                    it.reason.startsWith("parenthetical-pair-conflicting-outer-script")
+            },
+            decisions.toString(),
+        )
+    }
+
+    @Test
+    fun matchingOuterScriptResolvesTheParentheticalPairDirectly() {
+        val decisions = resolver.resolve("word——and stuff——word")
+
+        assertEquals(2, decisions.size)
+        assertTrue(
+            decisions.all {
+                it.role == FontRole.LatinText && it.source == "ParentheticalDashPairContext"
+            },
+            decisions.toString(),
+        )
+    }
+
+    @Test
+    fun punctuationBetweenRunsKeepsThemIndependent() {
+        val decisions = resolver.resolve("地点——北京，时间——明天", FontRoleContext(locale = "zh-Hans"))
+
+        assertEquals(2, decisions.size)
+        assertTrue(
+            decisions.all {
+                it.role == FontRole.CjkPunctuation && it.source == "DashEllipsisSurroundingScriptContext"
+            },
+            decisions.toString(),
+        )
+    }
+
+    @Test
+    fun symbolBetweenRunsKeepsThemIndependent() {
+        val decisions = resolver.resolve("时价——$100——很贵", FontRoleContext(locale = "zh-Hans"))
+
+        assertEquals(2, decisions.size)
+        assertTrue(
+            decisions.all { it.source == "DashEllipsisSurroundingScriptContext" },
+            decisions.toString(),
+        )
+    }
+
+    @Test
+    fun unequalRunLengthsDoNotPair() {
+        val decisions = resolver.resolve(
+            "想Jessica——Jessica是前女友—睡不着",
+            FontRoleContext(locale = "zh-Hans"),
+        )
+
+        assertEquals(2, decisions.size)
+        assertEquals(FontRole.LatinText, decisions[0].role)
+        assertEquals(FontRole.CjkPunctuation, decisions[1].role)
+    }
+
+    @Test
+    fun ellipsisRunsNeverPair() {
+        val decisions = resolver.resolve(
+            "想Jessica……Jessica是他的前女友……睡不着",
+            FontRoleContext(locale = "zh-Hans"),
+        )
+
+        assertEquals(2, decisions.size)
+        assertEquals(FontRole.LatinText, decisions[0].role)
+        assertEquals(FontRole.CjkPunctuation, decisions[1].role)
+    }
+
+    @Test
+    fun mandatoryBreakBetweenRunsKeepsThemIndependent() {
+        val decisions = resolver.resolve(
+            "想Jessica——Jessica\n是前女友——睡不着",
+            FontRoleContext(locale = "zh-Hans"),
+        )
+
+        assertEquals(2, decisions.size)
+        assertEquals(FontRole.LatinText, decisions[0].role)
+        assertEquals(FontRole.CjkPunctuation, decisions[1].role)
+    }
+
     private data class RoleCase(
         val text: String,
         val mark: Char,
@@ -137,6 +228,19 @@ class ContextualDashEllipsisLayoutTest {
         for (markIndex in text.indices.filter { text[it] == '—' || text[it] == '…' }) {
             assertEquals(FontRole.CjkPunctuation.name, result.fontDecisionAt(markIndex).role)
         }
+    }
+
+    @Test
+    fun parentheticalPairSharesOneFaceAndSubstitution() {
+        val text = "他彻夜想Jessica——Jessica是他的前女友——睡不着觉"
+        val result = layout(text)
+
+        val first = result.fontDecisionAt(text.indexOf("——"))
+        val second = result.fontDecisionAt(text.lastIndexOf("——"))
+        assertEquals(FontRole.CjkPunctuation.name, first.role)
+        assertEquals(FontRole.CjkPunctuation.name, second.role)
+        assertEquals("⸺", first.displayText)
+        assertEquals("⸺", second.displayText)
     }
 
     @Test

--- a/engine/src/commonTest/kotlin/org/tiqian/layout/DisplayGlyphSubstitutionEngineTest.kt
+++ b/engine/src/commonTest/kotlin/org/tiqian/layout/DisplayGlyphSubstitutionEngineTest.kt
@@ -115,6 +115,16 @@ class DisplayGlyphSubstitutionEngineTest {
         assertEquals(2, result.clusters.size)
         assertEquals("—", result.clusters[0].text)
         assertEquals("—", result.clusters[1].text)
+
+        // The same profile gate applies to a Latin-face contextual run.
+        val latin = engine.layout(
+            LayoutInput(
+                paragraphStyle = ParagraphStyle(firstLineIndent = Ic(0f)),
+                content = TiqianTextContent("A——B"),
+                constraints = LayoutConstraints(maxWidth = 320f),
+            ),
+        )
+        assertEquals(listOf("A", "—", "—", "B"), latin.clusters.map { it.text })
     }
 
     @Test

--- a/engine/src/jvmTest/resources/golden/layout-dumps-recorded/contextual-dash-ellipsis.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps-recorded/contextual-dash-ellipsis.txt
@@ -1,0 +1,171 @@
+fixture: contextual-dash-ellipsis
+text: 中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what?
+maxWidth: 1024.0
+== greedy ==
+size 584.1x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-63 natural=584.1 adjusted=584.1 visual=584.1 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=16.0
+cluster 1-2 '文' adv=16.0
+cluster 2-3 '—' adv=16.0
+cluster 3-4 '下' adv=16.0
+cluster 4-5 '句' adv=16.0
+cluster 5-6 '；' adv=16.0
+cluster 6-7 '等' adv=16.0
+cluster 7-8 '⋯' adv=16.0
+cluster 8-9 '真' adv=16.0
+cluster 9-10 '。' adv=16.0
+cluster 10-11 ' ' adv=5.0
+cluster 11-18 'English' adv=54.0
+cluster 18-19 ' ' adv=5.0
+cluster 19-20 '—' adv=16.0
+cluster 20-21 ' ' adv=5.0
+cluster 21-26 'next;' adv=37.0
+cluster 26-27 ' ' adv=5.0
+cluster 27-36 'ellipsis…' adv=65.0
+cluster 36-37 ' ' adv=5.0
+cluster 37-38 '/' adv=6.0
+cluster 38-39 ' ' adv=5.0
+cluster 39-45 'slash.' adv=43.0
+cluster 45-46 ' ' adv=5.0
+cluster 46-51 'A——B;' adv=58.0
+cluster 51-52 ' ' adv=5.0
+cluster 52-63 'Wait……what?' adv=105.2
+font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='下' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-5 role=CjkText key=cjk-primary display='句' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 5-6 role=CjkPunctuation key=cjk-primary display='；' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
+font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== lookahead ==
+size 584.1x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-63 natural=584.1 adjusted=584.1 visual=584.1 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=16.0
+cluster 1-2 '文' adv=16.0
+cluster 2-3 '—' adv=16.0
+cluster 3-4 '下' adv=16.0
+cluster 4-5 '句' adv=16.0
+cluster 5-6 '；' adv=16.0
+cluster 6-7 '等' adv=16.0
+cluster 7-8 '⋯' adv=16.0
+cluster 8-9 '真' adv=16.0
+cluster 9-10 '。' adv=16.0
+cluster 10-11 ' ' adv=5.0
+cluster 11-18 'English' adv=54.0
+cluster 18-19 ' ' adv=5.0
+cluster 19-20 '—' adv=16.0
+cluster 20-21 ' ' adv=5.0
+cluster 21-26 'next;' adv=37.0
+cluster 26-27 ' ' adv=5.0
+cluster 27-36 'ellipsis…' adv=65.0
+cluster 36-37 ' ' adv=5.0
+cluster 37-38 '/' adv=6.0
+cluster 38-39 ' ' adv=5.0
+cluster 39-45 'slash.' adv=43.0
+cluster 45-46 ' ' adv=5.0
+cluster 46-51 'A——B;' adv=58.0
+cluster 51-52 ' ' adv=5.0
+cluster 52-63 'Wait……what?' adv=105.2
+font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='下' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-5 role=CjkText key=cjk-primary display='句' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 5-6 role=CjkPunctuation key=cjk-primary display='；' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
+font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== paragraph-dp ==
+size 584.1x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-63 natural=584.1 adjusted=584.1 visual=584.1 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=16.0
+cluster 1-2 '文' adv=16.0
+cluster 2-3 '—' adv=16.0
+cluster 3-4 '下' adv=16.0
+cluster 4-5 '句' adv=16.0
+cluster 5-6 '；' adv=16.0
+cluster 6-7 '等' adv=16.0
+cluster 7-8 '⋯' adv=16.0
+cluster 8-9 '真' adv=16.0
+cluster 9-10 '。' adv=16.0
+cluster 10-11 ' ' adv=5.0
+cluster 11-18 'English' adv=54.0
+cluster 18-19 ' ' adv=5.0
+cluster 19-20 '—' adv=16.0
+cluster 20-21 ' ' adv=5.0
+cluster 21-26 'next;' adv=37.0
+cluster 26-27 ' ' adv=5.0
+cluster 27-36 'ellipsis…' adv=65.0
+cluster 36-37 ' ' adv=5.0
+cluster 37-38 '/' adv=6.0
+cluster 38-39 ' ' adv=5.0
+cluster 39-45 'slash.' adv=43.0
+cluster 45-46 ' ' adv=5.0
+cluster 46-51 'A——B;' adv=58.0
+cluster 51-52 ' ' adv=5.0
+cluster 52-63 'Wait……what?' adv=105.2
+font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='下' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-5 role=CjkText key=cjk-primary display='句' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 5-6 role=CjkPunctuation key=cjk-primary display='；' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
+font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault

--- a/engine/src/jvmTest/resources/golden/layout-dumps-recorded/contextual-dash-ellipsis.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps-recorded/contextual-dash-ellipsis.txt
@@ -1,10 +1,12 @@
 fixture: contextual-dash-ellipsis
-text: 中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what?
+text: 中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what? 中文—English\n——中文\n……
 maxWidth: 1024.0
 == greedy ==
-size 584.1x24.0
+size 688.1x72.0
 kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
-line[0] 0-63 natural=584.1 adjusted=584.1 visual=584.1 repair=- candidates=- justify=-
+line[0] 0-75 natural=688.1 adjusted=688.1 visual=688.1 repair=- candidates=- justify=-
+line[1] 75-80 natural=64.0 adjusted=64.0 visual=64.0 repair=- candidates=- justify=-
+line[2] 80-82 natural=32.0 adjusted=32.0 visual=32.0 repair=- candidates=- justify=-
 cluster 0-1 '中' adv=16.0
 cluster 1-2 '文' adv=16.0
 cluster 2-3 '—' adv=16.0
@@ -22,15 +24,31 @@ cluster 19-20 '—' adv=16.0
 cluster 20-21 ' ' adv=5.0
 cluster 21-26 'next;' adv=37.0
 cluster 26-27 ' ' adv=5.0
-cluster 27-36 'ellipsis…' adv=65.0
+cluster 27-35 'ellipsis' adv=51.0
+cluster 35-36 '…' adv=14.0
 cluster 36-37 ' ' adv=5.0
 cluster 37-38 '/' adv=6.0
 cluster 38-39 ' ' adv=5.0
 cluster 39-45 'slash.' adv=43.0
 cluster 45-46 ' ' adv=5.0
-cluster 46-51 'A——B;' adv=58.0
+cluster 46-47 'A' adv=11.0
+cluster 47-49 '——' adv=32.0
+cluster 49-51 'B;' adv=15.0
 cluster 51-52 ' ' adv=5.0
-cluster 52-63 'Wait……what?' adv=105.2
+cluster 52-56 'Wait' adv=33.2
+cluster 56-58 '……' adv=28.0
+cluster 58-63 'what?' adv=44.0
+cluster 63-64 ' ' adv=2.0
+cluster 64-65 '中' adv=16.0
+cluster 65-66 '文' adv=16.0
+cluster 66-67 '—' adv=16.0
+cluster 67-74 'English' adv=54.0
+cluster 74-75 '' adv=0.0
+cluster 75-77 '⸺' adv=32.0
+cluster 77-78 '中' adv=16.0
+cluster 78-79 '文' adv=16.0
+cluster 79-80 '' adv=0.0
+cluster 80-82 '⋯⋯' adv=32.0
 font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
@@ -41,26 +59,57 @@ font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolic
 font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
 font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
-font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-19 role=LatinText key=latin-primary display=' English ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 19-20 role=LatinText key=latin-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-35 role=LatinText key=latin-primary display=' next; ellipsis' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-36 role=LatinText key=latin-primary display='…' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 36-47 role=LatinText key=latin-primary display=' / slash. A' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 47-49 role=LatinText key=latin-primary display='——' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 49-56 role=LatinText key=latin-primary display='B; Wait' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 56-58 role=LatinText key=latin-primary display='……' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 58-64 role=LatinText key=latin-primary display='what? ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 64-65 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 65-66 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 66-67 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 67-74 role=LatinText key=latin-primary display='English' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 75-77 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 77-78 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 78-79 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 80-82 role=CjkPunctuation key=cjk-primary display='⋯⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026+U+2026->U+22EF+U+22EF
 role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 66-67 source='—' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=only-right-strong-script
+role-override 80-82 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=no-strong-script-context; paragraph-language=zh-Hans
 punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
 punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 66-67 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 75-77 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 80-81 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 81-82 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
 geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 66-67 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 75-77 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 80-82 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+autospace 63-64 side=gap boundary=EastAsianSpacing.Wide reduction=3.0
+mandatorybreak 74-75 afterCluster=36 reason=MandatoryBreakNoShape
+mandatorybreak 79-80 afterCluster=40 reason=MandatoryBreakNoShape
 linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
 == lookahead ==
-size 584.1x24.0
+size 688.1x72.0
 kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
-line[0] 0-63 natural=584.1 adjusted=584.1 visual=584.1 repair=- candidates=- justify=-
+line[0] 0-75 natural=688.1 adjusted=688.1 visual=688.1 repair=- candidates=- justify=-
+line[1] 75-80 natural=64.0 adjusted=64.0 visual=64.0 repair=- candidates=- justify=-
+line[2] 80-82 natural=32.0 adjusted=32.0 visual=32.0 repair=- candidates=- justify=-
 cluster 0-1 '中' adv=16.0
 cluster 1-2 '文' adv=16.0
 cluster 2-3 '—' adv=16.0
@@ -78,15 +127,31 @@ cluster 19-20 '—' adv=16.0
 cluster 20-21 ' ' adv=5.0
 cluster 21-26 'next;' adv=37.0
 cluster 26-27 ' ' adv=5.0
-cluster 27-36 'ellipsis…' adv=65.0
+cluster 27-35 'ellipsis' adv=51.0
+cluster 35-36 '…' adv=14.0
 cluster 36-37 ' ' adv=5.0
 cluster 37-38 '/' adv=6.0
 cluster 38-39 ' ' adv=5.0
 cluster 39-45 'slash.' adv=43.0
 cluster 45-46 ' ' adv=5.0
-cluster 46-51 'A——B;' adv=58.0
+cluster 46-47 'A' adv=11.0
+cluster 47-49 '——' adv=32.0
+cluster 49-51 'B;' adv=15.0
 cluster 51-52 ' ' adv=5.0
-cluster 52-63 'Wait……what?' adv=105.2
+cluster 52-56 'Wait' adv=33.2
+cluster 56-58 '……' adv=28.0
+cluster 58-63 'what?' adv=44.0
+cluster 63-64 ' ' adv=2.0
+cluster 64-65 '中' adv=16.0
+cluster 65-66 '文' adv=16.0
+cluster 66-67 '—' adv=16.0
+cluster 67-74 'English' adv=54.0
+cluster 74-75 '' adv=0.0
+cluster 75-77 '⸺' adv=32.0
+cluster 77-78 '中' adv=16.0
+cluster 78-79 '文' adv=16.0
+cluster 79-80 '' adv=0.0
+cluster 80-82 '⋯⋯' adv=32.0
 font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
@@ -97,26 +162,57 @@ font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolic
 font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
 font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
-font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-19 role=LatinText key=latin-primary display=' English ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 19-20 role=LatinText key=latin-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-35 role=LatinText key=latin-primary display=' next; ellipsis' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-36 role=LatinText key=latin-primary display='…' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 36-47 role=LatinText key=latin-primary display=' / slash. A' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 47-49 role=LatinText key=latin-primary display='——' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 49-56 role=LatinText key=latin-primary display='B; Wait' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 56-58 role=LatinText key=latin-primary display='……' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 58-64 role=LatinText key=latin-primary display='what? ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 64-65 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 65-66 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 66-67 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 67-74 role=LatinText key=latin-primary display='English' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 75-77 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 77-78 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 78-79 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 80-82 role=CjkPunctuation key=cjk-primary display='⋯⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026+U+2026->U+22EF+U+22EF
 role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 66-67 source='—' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=only-right-strong-script
+role-override 80-82 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=no-strong-script-context; paragraph-language=zh-Hans
 punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
 punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 66-67 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 75-77 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 80-81 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 81-82 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
 geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 66-67 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 75-77 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 80-82 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+autospace 63-64 side=gap boundary=EastAsianSpacing.Wide reduction=3.0
+mandatorybreak 74-75 afterCluster=36 reason=MandatoryBreakNoShape
+mandatorybreak 79-80 afterCluster=40 reason=MandatoryBreakNoShape
 linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
 == paragraph-dp ==
-size 584.1x24.0
+size 688.1x72.0
 kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
-line[0] 0-63 natural=584.1 adjusted=584.1 visual=584.1 repair=- candidates=- justify=-
+line[0] 0-75 natural=688.1 adjusted=688.1 visual=688.1 repair=- candidates=- justify=-
+line[1] 75-80 natural=64.0 adjusted=64.0 visual=64.0 repair=- candidates=- justify=-
+line[2] 80-82 natural=32.0 adjusted=32.0 visual=32.0 repair=- candidates=- justify=-
 cluster 0-1 '中' adv=16.0
 cluster 1-2 '文' adv=16.0
 cluster 2-3 '—' adv=16.0
@@ -134,15 +230,31 @@ cluster 19-20 '—' adv=16.0
 cluster 20-21 ' ' adv=5.0
 cluster 21-26 'next;' adv=37.0
 cluster 26-27 ' ' adv=5.0
-cluster 27-36 'ellipsis…' adv=65.0
+cluster 27-35 'ellipsis' adv=51.0
+cluster 35-36 '…' adv=14.0
 cluster 36-37 ' ' adv=5.0
 cluster 37-38 '/' adv=6.0
 cluster 38-39 ' ' adv=5.0
 cluster 39-45 'slash.' adv=43.0
 cluster 45-46 ' ' adv=5.0
-cluster 46-51 'A——B;' adv=58.0
+cluster 46-47 'A' adv=11.0
+cluster 47-49 '——' adv=32.0
+cluster 49-51 'B;' adv=15.0
 cluster 51-52 ' ' adv=5.0
-cluster 52-63 'Wait……what?' adv=105.2
+cluster 52-56 'Wait' adv=33.2
+cluster 56-58 '……' adv=28.0
+cluster 58-63 'what?' adv=44.0
+cluster 63-64 ' ' adv=2.0
+cluster 64-65 '中' adv=16.0
+cluster 65-66 '文' adv=16.0
+cluster 66-67 '—' adv=16.0
+cluster 67-74 'English' adv=54.0
+cluster 74-75 '' adv=0.0
+cluster 75-77 '⸺' adv=32.0
+cluster 77-78 '中' adv=16.0
+cluster 78-79 '文' adv=16.0
+cluster 79-80 '' adv=0.0
+cluster 80-82 '⋯⋯' adv=32.0
 font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
@@ -153,19 +265,48 @@ font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolic
 font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
 font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
-font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-19 role=LatinText key=latin-primary display=' English ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 19-20 role=LatinText key=latin-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-35 role=LatinText key=latin-primary display=' next; ellipsis' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-36 role=LatinText key=latin-primary display='…' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 36-47 role=LatinText key=latin-primary display=' / slash. A' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 47-49 role=LatinText key=latin-primary display='——' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 49-56 role=LatinText key=latin-primary display='B; Wait' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 56-58 role=LatinText key=latin-primary display='……' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 58-64 role=LatinText key=latin-primary display='what? ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 64-65 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 65-66 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 66-67 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 67-74 role=LatinText key=latin-primary display='English' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 75-77 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 77-78 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 78-79 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 80-82 role=CjkPunctuation key=cjk-primary display='⋯⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026+U+2026->U+22EF+U+22EF
 role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 66-67 source='—' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=only-right-strong-script
+role-override 80-82 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=no-strong-script-context; paragraph-language=zh-Hans
 punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
 punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 66-67 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 75-77 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 80-81 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 81-82 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
 geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 66-67 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 75-77 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 80-82 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+autospace 63-64 side=gap boundary=EastAsianSpacing.Wide reduction=3.0
+mandatorybreak 74-75 afterCluster=36 reason=MandatoryBreakNoShape
+mandatorybreak 79-80 afterCluster=40 reason=MandatoryBreakNoShape
 linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault

--- a/engine/src/jvmTest/resources/golden/layout-dumps-recorded/ellipsis-and-dash.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps-recorded/ellipsis-and-dash.txt
@@ -22,6 +22,8 @@ font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationG
 font 13-14 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 14-15 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 15-16 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
@@ -52,6 +54,8 @@ font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationG
 font 13-14 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 14-15 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 15-16 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
@@ -82,6 +86,8 @@ font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationG
 font 13-14 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 14-15 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 15-16 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression

--- a/engine/src/jvmTest/resources/golden/layout-dumps-recorded/fallback-roles.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps-recorded/fallback-roles.txt
@@ -21,6 +21,8 @@ font 9-11 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGl
 font 11-12 role=CjkText key=cjk-primary display='世' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 12-13 role=CjkText key=cjk-primary display='界' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 13-14 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 9-11 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 9-11 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
@@ -50,6 +52,8 @@ font 9-11 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGl
 font 11-12 role=CjkText key=cjk-primary display='世' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 12-13 role=CjkText key=cjk-primary display='界' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 13-14 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 9-11 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 9-11 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
@@ -79,6 +83,8 @@ font 9-11 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGl
 font 11-12 role=CjkText key=cjk-primary display='世' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 12-13 role=CjkText key=cjk-primary display='界' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 13-14 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 9-11 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
 punct 9-11 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression

--- a/engine/src/jvmTest/resources/golden/layout-dumps-recorded/parenthetical-dash-pairs.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps-recorded/parenthetical-dash-pairs.txt
@@ -1,0 +1,267 @@
+fixture: parenthetical-dash-pairs
+text: 他彻夜想Jessica——Jessica是他的前女友——睡不着觉。地点——北京，时间——明天。
+maxWidth: 1024.0
+== greedy ==
+size 636.3x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-47 natural=644.3 adjusted=636.3 visual=636.3 repair=- candidates=- justify=-
+cluster 0-1 '他' adv=16.0
+cluster 1-2 '彻' adv=16.0
+cluster 2-3 '夜' adv=16.0
+cluster 3-4 '想' adv=16.0
+cluster 4-11 'Jessica' adv=58.2
+cluster 11-13 '⸺' adv=32.0
+cluster 13-20 'Jessica' adv=58.2
+cluster 20-21 '是' adv=16.0
+cluster 21-22 '他' adv=16.0
+cluster 22-23 '的' adv=16.0
+cluster 23-24 '前' adv=16.0
+cluster 24-25 '女' adv=16.0
+cluster 25-26 '友' adv=16.0
+cluster 26-28 '⸺' adv=32.0
+cluster 28-29 '睡' adv=16.0
+cluster 29-30 '不' adv=16.0
+cluster 30-31 '着' adv=16.0
+cluster 31-32 '觉' adv=16.0
+cluster 32-33 '。' adv=16.0
+cluster 33-34 '地' adv=16.0
+cluster 34-35 '点' adv=16.0
+cluster 35-37 '⸺' adv=32.0
+cluster 37-38 '北' adv=16.0
+cluster 38-39 '京' adv=16.0
+cluster 39-40 '，' adv=16.0
+cluster 40-41 '时' adv=16.0
+cluster 41-42 '间' adv=16.0
+cluster 42-44 '⸺' adv=32.0
+cluster 44-45 '明' adv=16.0
+cluster 45-46 '天' adv=16.0
+cluster 46-47 '。' adv=8.0
+font 0-1 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='彻' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkText key=cjk-primary display='夜' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='想' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-11 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 13-20 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-21 role=CjkText key=cjk-primary display='是' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 21-22 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 22-23 role=CjkText key=cjk-primary display='的' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 23-24 role=CjkText key=cjk-primary display='前' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 24-25 role=CjkText key=cjk-primary display='女' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 25-26 role=CjkText key=cjk-primary display='友' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 26-28 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 28-29 role=CjkText key=cjk-primary display='睡' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 29-30 role=CjkText key=cjk-primary display='不' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 30-31 role=CjkText key=cjk-primary display='着' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 31-32 role=CjkText key=cjk-primary display='觉' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 32-33 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 33-34 role=CjkText key=cjk-primary display='地' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 34-35 role=CjkText key=cjk-primary display='点' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-37 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 37-38 role=CjkText key=cjk-primary display='北' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 38-39 role=CjkText key=cjk-primary display='京' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 39-40 role=CjkPunctuation key=cjk-primary display='，' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 40-41 role=CjkText key=cjk-primary display='时' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 41-42 role=CjkText key=cjk-primary display='间' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 42-44 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 44-45 role=CjkText key=cjk-primary display='明' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 45-46 role=CjkText key=cjk-primary display='天' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 46-47 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 26-28 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 35-37 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 42-44 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 26-28 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 32-33 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 35-37 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 39-40 '，' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 42-44 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 46-47 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+geom 11-13 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 26-28 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 32-33 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 35-37 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 39-40 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 42-44 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 46-47 body=8.0 lead=0.0/0.0 trail=8.0/8.0 justify=0.0 resolved=8.0
+autospace 4-11 side=leading boundary=EastAsianSpacing.Wide reduction=-2.0
+autospace 13-20 side=trailing boundary=EastAsianSpacing.Wide reduction=-2.0
+edgetrim 46-47 side=trailing trim=8.0 reason=LineEndHalfWidthPunctuation
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== lookahead ==
+size 636.3x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-47 natural=644.3 adjusted=636.3 visual=636.3 repair=- candidates=- justify=-
+cluster 0-1 '他' adv=16.0
+cluster 1-2 '彻' adv=16.0
+cluster 2-3 '夜' adv=16.0
+cluster 3-4 '想' adv=16.0
+cluster 4-11 'Jessica' adv=58.2
+cluster 11-13 '⸺' adv=32.0
+cluster 13-20 'Jessica' adv=58.2
+cluster 20-21 '是' adv=16.0
+cluster 21-22 '他' adv=16.0
+cluster 22-23 '的' adv=16.0
+cluster 23-24 '前' adv=16.0
+cluster 24-25 '女' adv=16.0
+cluster 25-26 '友' adv=16.0
+cluster 26-28 '⸺' adv=32.0
+cluster 28-29 '睡' adv=16.0
+cluster 29-30 '不' adv=16.0
+cluster 30-31 '着' adv=16.0
+cluster 31-32 '觉' adv=16.0
+cluster 32-33 '。' adv=16.0
+cluster 33-34 '地' adv=16.0
+cluster 34-35 '点' adv=16.0
+cluster 35-37 '⸺' adv=32.0
+cluster 37-38 '北' adv=16.0
+cluster 38-39 '京' adv=16.0
+cluster 39-40 '，' adv=16.0
+cluster 40-41 '时' adv=16.0
+cluster 41-42 '间' adv=16.0
+cluster 42-44 '⸺' adv=32.0
+cluster 44-45 '明' adv=16.0
+cluster 45-46 '天' adv=16.0
+cluster 46-47 '。' adv=8.0
+font 0-1 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='彻' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkText key=cjk-primary display='夜' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='想' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-11 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 13-20 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-21 role=CjkText key=cjk-primary display='是' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 21-22 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 22-23 role=CjkText key=cjk-primary display='的' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 23-24 role=CjkText key=cjk-primary display='前' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 24-25 role=CjkText key=cjk-primary display='女' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 25-26 role=CjkText key=cjk-primary display='友' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 26-28 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 28-29 role=CjkText key=cjk-primary display='睡' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 29-30 role=CjkText key=cjk-primary display='不' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 30-31 role=CjkText key=cjk-primary display='着' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 31-32 role=CjkText key=cjk-primary display='觉' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 32-33 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 33-34 role=CjkText key=cjk-primary display='地' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 34-35 role=CjkText key=cjk-primary display='点' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-37 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 37-38 role=CjkText key=cjk-primary display='北' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 38-39 role=CjkText key=cjk-primary display='京' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 39-40 role=CjkPunctuation key=cjk-primary display='，' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 40-41 role=CjkText key=cjk-primary display='时' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 41-42 role=CjkText key=cjk-primary display='间' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 42-44 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 44-45 role=CjkText key=cjk-primary display='明' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 45-46 role=CjkText key=cjk-primary display='天' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 46-47 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 26-28 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 35-37 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 42-44 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 26-28 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 32-33 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 35-37 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 39-40 '，' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 42-44 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 46-47 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+geom 11-13 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 26-28 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 32-33 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 35-37 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 39-40 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 42-44 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 46-47 body=8.0 lead=0.0/0.0 trail=8.0/8.0 justify=0.0 resolved=8.0
+autospace 4-11 side=leading boundary=EastAsianSpacing.Wide reduction=-2.0
+autospace 13-20 side=trailing boundary=EastAsianSpacing.Wide reduction=-2.0
+edgetrim 46-47 side=trailing trim=8.0 reason=LineEndHalfWidthPunctuation
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== paragraph-dp ==
+size 636.3x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-47 natural=644.3 adjusted=636.3 visual=636.3 repair=- candidates=- justify=-
+cluster 0-1 '他' adv=16.0
+cluster 1-2 '彻' adv=16.0
+cluster 2-3 '夜' adv=16.0
+cluster 3-4 '想' adv=16.0
+cluster 4-11 'Jessica' adv=58.2
+cluster 11-13 '⸺' adv=32.0
+cluster 13-20 'Jessica' adv=58.2
+cluster 20-21 '是' adv=16.0
+cluster 21-22 '他' adv=16.0
+cluster 22-23 '的' adv=16.0
+cluster 23-24 '前' adv=16.0
+cluster 24-25 '女' adv=16.0
+cluster 25-26 '友' adv=16.0
+cluster 26-28 '⸺' adv=32.0
+cluster 28-29 '睡' adv=16.0
+cluster 29-30 '不' adv=16.0
+cluster 30-31 '着' adv=16.0
+cluster 31-32 '觉' adv=16.0
+cluster 32-33 '。' adv=16.0
+cluster 33-34 '地' adv=16.0
+cluster 34-35 '点' adv=16.0
+cluster 35-37 '⸺' adv=32.0
+cluster 37-38 '北' adv=16.0
+cluster 38-39 '京' adv=16.0
+cluster 39-40 '，' adv=16.0
+cluster 40-41 '时' adv=16.0
+cluster 41-42 '间' adv=16.0
+cluster 42-44 '⸺' adv=32.0
+cluster 44-45 '明' adv=16.0
+cluster 45-46 '天' adv=16.0
+cluster 46-47 '。' adv=8.0
+font 0-1 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='彻' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkText key=cjk-primary display='夜' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='想' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-11 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 13-20 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-21 role=CjkText key=cjk-primary display='是' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 21-22 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 22-23 role=CjkText key=cjk-primary display='的' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 23-24 role=CjkText key=cjk-primary display='前' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 24-25 role=CjkText key=cjk-primary display='女' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 25-26 role=CjkText key=cjk-primary display='友' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 26-28 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 28-29 role=CjkText key=cjk-primary display='睡' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 29-30 role=CjkText key=cjk-primary display='不' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 30-31 role=CjkText key=cjk-primary display='着' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 31-32 role=CjkText key=cjk-primary display='觉' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 32-33 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 33-34 role=CjkText key=cjk-primary display='地' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 34-35 role=CjkText key=cjk-primary display='点' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-37 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 37-38 role=CjkText key=cjk-primary display='北' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 38-39 role=CjkText key=cjk-primary display='京' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 39-40 role=CjkPunctuation key=cjk-primary display='，' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 40-41 role=CjkText key=cjk-primary display='时' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 41-42 role=CjkText key=cjk-primary display='间' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 42-44 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 44-45 role=CjkText key=cjk-primary display='明' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 45-46 role=CjkText key=cjk-primary display='天' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 46-47 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 26-28 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 35-37 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 42-44 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 26-28 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 32-33 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 35-37 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 39-40 '，' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+punct 42-44 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Leading source=InkBoundsFittedBodyCompression
+punct 46-47 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
+geom 11-13 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 26-28 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 32-33 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 35-37 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 39-40 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 42-44 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 46-47 body=8.0 lead=0.0/0.0 trail=8.0/8.0 justify=0.0 resolved=8.0
+autospace 4-11 side=leading boundary=EastAsianSpacing.Wide reduction=-2.0
+autospace 13-20 side=trailing boundary=EastAsianSpacing.Wide reduction=-2.0
+edgetrim 46-47 side=trailing trim=8.0 reason=LineEndHalfWidthPunctuation
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault

--- a/engine/src/jvmTest/resources/golden/layout-dumps-recorded/real-paragraph-1.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps-recorded/real-paragraph-1.txt
@@ -352,6 +352,9 @@ font 181-182 role=CjkText key=cjk-primary display='太' sub=CjkPunctuationGlyphP
 font 182-183 role=CjkText key=cjk-primary display='离' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 183-184 role=CjkText key=cjk-primary display='谱' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 184-185 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 62-64 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 130-132 source='……' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 punct 2-3 '（' class=Opening adv=17.0 body=9.0 lead=8.0 trail=0.0 anchor=Trailing source=FontHaltFittedBodyCompression expand=1.0 halt=8.0 haltWarn=halt-trim-limited-by-default-ink-bounds
 punct 9-10 '）' class=Closing adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
 punct 23-24 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
@@ -753,6 +756,9 @@ font 181-182 role=CjkText key=cjk-primary display='太' sub=CjkPunctuationGlyphP
 font 182-183 role=CjkText key=cjk-primary display='离' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 183-184 role=CjkText key=cjk-primary display='谱' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 184-185 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 62-64 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 130-132 source='……' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 punct 2-3 '（' class=Opening adv=17.0 body=9.0 lead=8.0 trail=0.0 anchor=Trailing source=FontHaltFittedBodyCompression expand=1.0 halt=8.0 haltWarn=halt-trim-limited-by-default-ink-bounds
 punct 9-10 '）' class=Closing adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
 punct 23-24 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
@@ -1154,6 +1160,9 @@ font 181-182 role=CjkText key=cjk-primary display='太' sub=CjkPunctuationGlyphP
 font 182-183 role=CjkText key=cjk-primary display='离' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 183-184 role=CjkText key=cjk-primary display='谱' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 184-185 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 62-64 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 130-132 source='……' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 punct 2-3 '（' class=Opening adv=17.0 body=9.0 lead=8.0 trail=0.0 anchor=Trailing source=FontHaltFittedBodyCompression expand=1.0 halt=8.0 haltWarn=halt-trim-limited-by-default-ink-bounds
 punct 9-10 '）' class=Closing adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0
 punct 23-24 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=FontHaltFittedBodyCompression halt=8.0

--- a/engine/src/jvmTest/resources/golden/layout-dumps/contextual-dash-ellipsis.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps/contextual-dash-ellipsis.txt
@@ -1,0 +1,171 @@
+fixture: contextual-dash-ellipsis
+text: 中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what?
+maxWidth: 1024.0
+== greedy ==
+size 944.0x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-63 natural=944.0 adjusted=944.0 visual=944.0 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=16.0
+cluster 1-2 '文' adv=16.0
+cluster 2-3 '—' adv=16.0
+cluster 3-4 '下' adv=16.0
+cluster 4-5 '句' adv=16.0
+cluster 5-6 '；' adv=16.0
+cluster 6-7 '等' adv=16.0
+cluster 7-8 '⋯' adv=16.0
+cluster 8-9 '真' adv=16.0
+cluster 9-10 '。' adv=16.0
+cluster 10-11 ' ' adv=8.0
+cluster 11-18 'English' adv=112.0
+cluster 18-19 ' ' adv=8.0
+cluster 19-20 '—' adv=16.0
+cluster 20-21 ' ' adv=8.0
+cluster 21-26 'next;' adv=80.0
+cluster 26-27 ' ' adv=8.0
+cluster 27-36 'ellipsis…' adv=144.0
+cluster 36-37 ' ' adv=8.0
+cluster 37-38 '/' adv=16.0
+cluster 38-39 ' ' adv=8.0
+cluster 39-45 'slash.' adv=96.0
+cluster 45-46 ' ' adv=8.0
+cluster 46-51 'A——B;' adv=80.0
+cluster 51-52 ' ' adv=8.0
+cluster 52-63 'Wait……what?' adv=176.0
+font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='下' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-5 role=CjkText key=cjk-primary display='句' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 5-6 role=CjkPunctuation key=cjk-primary display='；' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
+font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== lookahead ==
+size 944.0x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-63 natural=944.0 adjusted=944.0 visual=944.0 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=16.0
+cluster 1-2 '文' adv=16.0
+cluster 2-3 '—' adv=16.0
+cluster 3-4 '下' adv=16.0
+cluster 4-5 '句' adv=16.0
+cluster 5-6 '；' adv=16.0
+cluster 6-7 '等' adv=16.0
+cluster 7-8 '⋯' adv=16.0
+cluster 8-9 '真' adv=16.0
+cluster 9-10 '。' adv=16.0
+cluster 10-11 ' ' adv=8.0
+cluster 11-18 'English' adv=112.0
+cluster 18-19 ' ' adv=8.0
+cluster 19-20 '—' adv=16.0
+cluster 20-21 ' ' adv=8.0
+cluster 21-26 'next;' adv=80.0
+cluster 26-27 ' ' adv=8.0
+cluster 27-36 'ellipsis…' adv=144.0
+cluster 36-37 ' ' adv=8.0
+cluster 37-38 '/' adv=16.0
+cluster 38-39 ' ' adv=8.0
+cluster 39-45 'slash.' adv=96.0
+cluster 45-46 ' ' adv=8.0
+cluster 46-51 'A——B;' adv=80.0
+cluster 51-52 ' ' adv=8.0
+cluster 52-63 'Wait……what?' adv=176.0
+font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='下' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-5 role=CjkText key=cjk-primary display='句' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 5-6 role=CjkPunctuation key=cjk-primary display='；' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
+font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== paragraph-dp ==
+size 944.0x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-63 natural=944.0 adjusted=944.0 visual=944.0 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=16.0
+cluster 1-2 '文' adv=16.0
+cluster 2-3 '—' adv=16.0
+cluster 3-4 '下' adv=16.0
+cluster 4-5 '句' adv=16.0
+cluster 5-6 '；' adv=16.0
+cluster 6-7 '等' adv=16.0
+cluster 7-8 '⋯' adv=16.0
+cluster 8-9 '真' adv=16.0
+cluster 9-10 '。' adv=16.0
+cluster 10-11 ' ' adv=8.0
+cluster 11-18 'English' adv=112.0
+cluster 18-19 ' ' adv=8.0
+cluster 19-20 '—' adv=16.0
+cluster 20-21 ' ' adv=8.0
+cluster 21-26 'next;' adv=80.0
+cluster 26-27 ' ' adv=8.0
+cluster 27-36 'ellipsis…' adv=144.0
+cluster 36-37 ' ' adv=8.0
+cluster 37-38 '/' adv=16.0
+cluster 38-39 ' ' adv=8.0
+cluster 39-45 'slash.' adv=96.0
+cluster 45-46 ' ' adv=8.0
+cluster 46-51 'A——B;' adv=80.0
+cluster 51-52 ' ' adv=8.0
+cluster 52-63 'Wait……what?' adv=176.0
+font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='下' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-5 role=CjkText key=cjk-primary display='句' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 5-6 role=CjkPunctuation key=cjk-primary display='；' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
+font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault

--- a/engine/src/jvmTest/resources/golden/layout-dumps/contextual-dash-ellipsis.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps/contextual-dash-ellipsis.txt
@@ -1,19 +1,22 @@
 fixture: contextual-dash-ellipsis
-text: 中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what?
+text: 中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what? 中文—English\n——中文\n……
 maxWidth: 1024.0
 == greedy ==
-size 944.0x24.0
+size 1024.0x96.0
 kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
-line[0] 0-63 natural=944.0 adjusted=944.0 visual=944.0 repair=- candidates=- justify=-
-cluster 0-1 '中' adv=16.0
+line[0] 0-67 natural=994.0 adjusted=994.0 visual=1024.0 repair=- candidates=- justify=deficit=30.0->0.0 CjkLatinSpace@63+3.3,CjkInterChar@0+2.7,CjkInterChar@3+2.7,CjkInterChar@4+2.7,CjkInterChar@5+2.7,CjkInterChar@8+2.7,CjkInterChar@64+2.7,CjkInterChar@26+2.7,CjkInterChar@45+2.7,CjkInterChar@51+2.7,CjkInterChar@63+2.7
+line[1] 67-75 natural=112.0 adjusted=112.0 visual=112.0 repair=- candidates=- justify=-
+line[2] 75-80 natural=64.0 adjusted=64.0 visual=64.0 repair=- candidates=- justify=-
+line[3] 80-82 natural=32.0 adjusted=32.0 visual=32.0 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=18.7
 cluster 1-2 '文' adv=16.0
 cluster 2-3 '—' adv=16.0
-cluster 3-4 '下' adv=16.0
-cluster 4-5 '句' adv=16.0
-cluster 5-6 '；' adv=16.0
+cluster 3-4 '下' adv=18.7
+cluster 4-5 '句' adv=18.7
+cluster 5-6 '；' adv=18.7
 cluster 6-7 '等' adv=16.0
 cluster 7-8 '⋯' adv=16.0
-cluster 8-9 '真' adv=16.0
+cluster 8-9 '真' adv=18.7
 cluster 9-10 '。' adv=16.0
 cluster 10-11 ' ' adv=8.0
 cluster 11-18 'English' adv=112.0
@@ -21,16 +24,32 @@ cluster 18-19 ' ' adv=8.0
 cluster 19-20 '—' adv=16.0
 cluster 20-21 ' ' adv=8.0
 cluster 21-26 'next;' adv=80.0
-cluster 26-27 ' ' adv=8.0
-cluster 27-36 'ellipsis…' adv=144.0
+cluster 26-27 ' ' adv=10.7
+cluster 27-35 'ellipsis' adv=128.0
+cluster 35-36 '…' adv=16.0
 cluster 36-37 ' ' adv=8.0
 cluster 37-38 '/' adv=16.0
 cluster 38-39 ' ' adv=8.0
 cluster 39-45 'slash.' adv=96.0
-cluster 45-46 ' ' adv=8.0
-cluster 46-51 'A——B;' adv=80.0
-cluster 51-52 ' ' adv=8.0
-cluster 52-63 'Wait……what?' adv=176.0
+cluster 45-46 ' ' adv=10.7
+cluster 46-47 'A' adv=16.0
+cluster 47-49 '——' adv=32.0
+cluster 49-51 'B;' adv=32.0
+cluster 51-52 ' ' adv=10.7
+cluster 52-56 'Wait' adv=64.0
+cluster 56-58 '……' adv=32.0
+cluster 58-63 'what?' adv=80.0
+cluster 63-64 ' ' adv=8.0
+cluster 64-65 '中' adv=18.7
+cluster 65-66 '文' adv=16.0
+cluster 66-67 '—' adv=16.0
+cluster 67-74 'English' adv=112.0
+cluster 74-75 '' adv=0.0
+cluster 75-77 '⸺' adv=32.0
+cluster 77-78 '中' adv=16.0
+cluster 78-79 '文' adv=16.0
+cluster 79-80 '' adv=0.0
+cluster 80-82 '⋯⋯' adv=32.0
 font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
@@ -41,35 +60,67 @@ font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolic
 font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
 font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
-font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-19 role=LatinText key=latin-primary display=' English ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 19-20 role=LatinText key=latin-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-35 role=LatinText key=latin-primary display=' next; ellipsis' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-36 role=LatinText key=latin-primary display='…' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 36-47 role=LatinText key=latin-primary display=' / slash. A' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 47-49 role=LatinText key=latin-primary display='——' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 49-56 role=LatinText key=latin-primary display='B; Wait' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 56-58 role=LatinText key=latin-primary display='……' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 58-64 role=LatinText key=latin-primary display='what? ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 64-65 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 65-66 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 66-67 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 67-74 role=LatinText key=latin-primary display='English' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 75-77 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 77-78 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 78-79 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 80-82 role=CjkPunctuation key=cjk-primary display='⋯⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026+U+2026->U+22EF+U+22EF
 role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 66-67 source='—' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=only-right-strong-script
+role-override 80-82 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=no-strong-script-context; paragraph-language=zh-Hans
 punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 66-67 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 75-77 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 80-81 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 81-82 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
-geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=2.7 resolved=18.7
 geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 66-67 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 75-77 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 80-82 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+autospace 63-64 side=gap boundary=EastAsianSpacing.Wide reduction=6.0
+mandatorybreak 74-75 afterCluster=36 reason=MandatoryBreakNoShape
+mandatorybreak 79-80 afterCluster=40 reason=MandatoryBreakNoShape
 linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
 == lookahead ==
-size 944.0x24.0
+size 1024.0x96.0
 kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
-line[0] 0-63 natural=944.0 adjusted=944.0 visual=944.0 repair=- candidates=- justify=-
-cluster 0-1 '中' adv=16.0
+line[0] 0-67 natural=994.0 adjusted=994.0 visual=1024.0 repair=- candidates=- justify=deficit=30.0->0.0 CjkLatinSpace@63+3.3,CjkInterChar@0+2.7,CjkInterChar@3+2.7,CjkInterChar@4+2.7,CjkInterChar@5+2.7,CjkInterChar@8+2.7,CjkInterChar@64+2.7,CjkInterChar@26+2.7,CjkInterChar@45+2.7,CjkInterChar@51+2.7,CjkInterChar@63+2.7
+line[1] 67-75 natural=112.0 adjusted=112.0 visual=112.0 repair=- candidates=- justify=-
+line[2] 75-80 natural=64.0 adjusted=64.0 visual=64.0 repair=- candidates=- justify=-
+line[3] 80-82 natural=32.0 adjusted=32.0 visual=32.0 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=18.7
 cluster 1-2 '文' adv=16.0
 cluster 2-3 '—' adv=16.0
-cluster 3-4 '下' adv=16.0
-cluster 4-5 '句' adv=16.0
-cluster 5-6 '；' adv=16.0
+cluster 3-4 '下' adv=18.7
+cluster 4-5 '句' adv=18.7
+cluster 5-6 '；' adv=18.7
 cluster 6-7 '等' adv=16.0
 cluster 7-8 '⋯' adv=16.0
-cluster 8-9 '真' adv=16.0
+cluster 8-9 '真' adv=18.7
 cluster 9-10 '。' adv=16.0
 cluster 10-11 ' ' adv=8.0
 cluster 11-18 'English' adv=112.0
@@ -77,16 +128,32 @@ cluster 18-19 ' ' adv=8.0
 cluster 19-20 '—' adv=16.0
 cluster 20-21 ' ' adv=8.0
 cluster 21-26 'next;' adv=80.0
-cluster 26-27 ' ' adv=8.0
-cluster 27-36 'ellipsis…' adv=144.0
+cluster 26-27 ' ' adv=10.7
+cluster 27-35 'ellipsis' adv=128.0
+cluster 35-36 '…' adv=16.0
 cluster 36-37 ' ' adv=8.0
 cluster 37-38 '/' adv=16.0
 cluster 38-39 ' ' adv=8.0
 cluster 39-45 'slash.' adv=96.0
-cluster 45-46 ' ' adv=8.0
-cluster 46-51 'A——B;' adv=80.0
-cluster 51-52 ' ' adv=8.0
-cluster 52-63 'Wait……what?' adv=176.0
+cluster 45-46 ' ' adv=10.7
+cluster 46-47 'A' adv=16.0
+cluster 47-49 '——' adv=32.0
+cluster 49-51 'B;' adv=32.0
+cluster 51-52 ' ' adv=10.7
+cluster 52-56 'Wait' adv=64.0
+cluster 56-58 '……' adv=32.0
+cluster 58-63 'what?' adv=80.0
+cluster 63-64 ' ' adv=8.0
+cluster 64-65 '中' adv=18.7
+cluster 65-66 '文' adv=16.0
+cluster 66-67 '—' adv=16.0
+cluster 67-74 'English' adv=112.0
+cluster 74-75 '' adv=0.0
+cluster 75-77 '⸺' adv=32.0
+cluster 77-78 '中' adv=16.0
+cluster 78-79 '文' adv=16.0
+cluster 79-80 '' adv=0.0
+cluster 80-82 '⋯⋯' adv=32.0
 font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
@@ -97,35 +164,67 @@ font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolic
 font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
 font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
-font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-19 role=LatinText key=latin-primary display=' English ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 19-20 role=LatinText key=latin-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-35 role=LatinText key=latin-primary display=' next; ellipsis' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-36 role=LatinText key=latin-primary display='…' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 36-47 role=LatinText key=latin-primary display=' / slash. A' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 47-49 role=LatinText key=latin-primary display='——' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 49-56 role=LatinText key=latin-primary display='B; Wait' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 56-58 role=LatinText key=latin-primary display='……' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 58-64 role=LatinText key=latin-primary display='what? ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 64-65 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 65-66 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 66-67 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 67-74 role=LatinText key=latin-primary display='English' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 75-77 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 77-78 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 78-79 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 80-82 role=CjkPunctuation key=cjk-primary display='⋯⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026+U+2026->U+22EF+U+22EF
 role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 66-67 source='—' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=only-right-strong-script
+role-override 80-82 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=no-strong-script-context; paragraph-language=zh-Hans
 punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 66-67 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 75-77 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 80-81 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 81-82 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
-geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=2.7 resolved=18.7
 geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 66-67 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 75-77 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 80-82 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+autospace 63-64 side=gap boundary=EastAsianSpacing.Wide reduction=6.0
+mandatorybreak 74-75 afterCluster=36 reason=MandatoryBreakNoShape
+mandatorybreak 79-80 afterCluster=40 reason=MandatoryBreakNoShape
 linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
 == paragraph-dp ==
-size 944.0x24.0
+size 1024.0x96.0
 kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
-line[0] 0-63 natural=944.0 adjusted=944.0 visual=944.0 repair=- candidates=- justify=-
-cluster 0-1 '中' adv=16.0
+line[0] 0-67 natural=994.0 adjusted=994.0 visual=1024.0 repair=- candidates=- justify=deficit=30.0->0.0 CjkLatinSpace@63+3.3,CjkInterChar@0+2.7,CjkInterChar@3+2.7,CjkInterChar@4+2.7,CjkInterChar@5+2.7,CjkInterChar@8+2.7,CjkInterChar@64+2.7,CjkInterChar@26+2.7,CjkInterChar@45+2.7,CjkInterChar@51+2.7,CjkInterChar@63+2.7
+line[1] 67-75 natural=112.0 adjusted=112.0 visual=112.0 repair=- candidates=- justify=-
+line[2] 75-80 natural=64.0 adjusted=64.0 visual=64.0 repair=- candidates=- justify=-
+line[3] 80-82 natural=32.0 adjusted=32.0 visual=32.0 repair=- candidates=- justify=-
+cluster 0-1 '中' adv=18.7
 cluster 1-2 '文' adv=16.0
 cluster 2-3 '—' adv=16.0
-cluster 3-4 '下' adv=16.0
-cluster 4-5 '句' adv=16.0
-cluster 5-6 '；' adv=16.0
+cluster 3-4 '下' adv=18.7
+cluster 4-5 '句' adv=18.7
+cluster 5-6 '；' adv=18.7
 cluster 6-7 '等' adv=16.0
 cluster 7-8 '⋯' adv=16.0
-cluster 8-9 '真' adv=16.0
+cluster 8-9 '真' adv=18.7
 cluster 9-10 '。' adv=16.0
 cluster 10-11 ' ' adv=8.0
 cluster 11-18 'English' adv=112.0
@@ -133,16 +232,32 @@ cluster 18-19 ' ' adv=8.0
 cluster 19-20 '—' adv=16.0
 cluster 20-21 ' ' adv=8.0
 cluster 21-26 'next;' adv=80.0
-cluster 26-27 ' ' adv=8.0
-cluster 27-36 'ellipsis…' adv=144.0
+cluster 26-27 ' ' adv=10.7
+cluster 27-35 'ellipsis' adv=128.0
+cluster 35-36 '…' adv=16.0
 cluster 36-37 ' ' adv=8.0
 cluster 37-38 '/' adv=16.0
 cluster 38-39 ' ' adv=8.0
 cluster 39-45 'slash.' adv=96.0
-cluster 45-46 ' ' adv=8.0
-cluster 46-51 'A——B;' adv=80.0
-cluster 51-52 ' ' adv=8.0
-cluster 52-63 'Wait……what?' adv=176.0
+cluster 45-46 ' ' adv=10.7
+cluster 46-47 'A' adv=16.0
+cluster 47-49 '——' adv=32.0
+cluster 49-51 'B;' adv=32.0
+cluster 51-52 ' ' adv=10.7
+cluster 52-56 'Wait' adv=64.0
+cluster 56-58 '……' adv=32.0
+cluster 58-63 'what?' adv=80.0
+cluster 63-64 ' ' adv=8.0
+cluster 64-65 '中' adv=18.7
+cluster 65-66 '文' adv=16.0
+cluster 66-67 '—' adv=16.0
+cluster 67-74 'English' adv=112.0
+cluster 74-75 '' adv=0.0
+cluster 75-77 '⸺' adv=32.0
+cluster 77-78 '中' adv=16.0
+cluster 78-79 '文' adv=16.0
+cluster 79-80 '' adv=0.0
+cluster 80-82 '⋯⋯' adv=32.0
 font 0-1 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 1-2 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 2-3 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
@@ -153,19 +268,48 @@ font 6-7 role=CjkText key=cjk-primary display='等' sub=CjkPunctuationGlyphPolic
 font 7-8 role=CjkPunctuation key=cjk-primary display='⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026->U+22EF
 font 8-9 role=CjkText key=cjk-primary display='真' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 9-10 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
-font 10-63 role=LatinText key=latin-primary display=' English — next; ellipsis… / slash. A——B; Wait……what?' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 10-19 role=LatinText key=latin-primary display=' English ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 19-20 role=LatinText key=latin-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-35 role=LatinText key=latin-primary display=' next; ellipsis' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-36 role=LatinText key=latin-primary display='…' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 36-47 role=LatinText key=latin-primary display=' / slash. A' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 47-49 role=LatinText key=latin-primary display='——' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 49-56 role=LatinText key=latin-primary display='B; Wait' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 56-58 role=LatinText key=latin-primary display='……' sub=CjkRoleGatedDisplaySubstitution:preserve-role-LatinText
+font 58-64 role=LatinText key=latin-primary display='what? ' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 64-65 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 65-66 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 66-67 role=CjkPunctuation key=cjk-primary display='—' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 67-74 role=LatinText key=latin-primary display='English' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 75-77 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 77-78 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 78-79 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 80-82 role=CjkPunctuation key=cjk-primary display='⋯⋯' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2026+U+2026->U+22EF+U+22EF
 role-override 2-3 source='—' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 7-8 source='…' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 19-20 source='—' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 35-36 source='…' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 47-49 source='——' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 role-override 56-58 source='……' CjkPunctuation->LatinText policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 66-67 source='—' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=only-right-strong-script
+role-override 80-82 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=no-strong-script-context; paragraph-language=zh-Hans
 punct 2-3 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 5-6 '；' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 7-8 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-10 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 66-67 '—' class=Dash adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 75-77 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 80-81 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 81-82 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 geom 2-3 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
-geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 5-6 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=2.7 resolved=18.7
 geom 7-8 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
 geom 9-10 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 66-67 body=16.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=16.0
+geom 75-77 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 80-82 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+autospace 63-64 side=gap boundary=EastAsianSpacing.Wide reduction=6.0
+mandatorybreak 74-75 afterCluster=36 reason=MandatoryBreakNoShape
+mandatorybreak 79-80 afterCluster=40 reason=MandatoryBreakNoShape
 linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault

--- a/engine/src/jvmTest/resources/golden/layout-dumps/ellipsis-and-dash.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps/ellipsis-and-dash.txt
@@ -23,6 +23,8 @@ font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationG
 font 13-14 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 14-15 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 15-16 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
@@ -54,6 +56,8 @@ font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationG
 font 13-14 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 14-15 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 15-16 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
@@ -85,6 +89,8 @@ font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationG
 font 13-14 role=CjkText key=cjk-primary display='中' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 14-15 role=CjkText key=cjk-primary display='文' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 15-16 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds

--- a/engine/src/jvmTest/resources/golden/layout-dumps/fallback-roles.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps/fallback-roles.txt
@@ -21,6 +21,8 @@ font 9-11 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGl
 font 11-12 role=CjkText key=cjk-primary display='世' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 12-13 role=CjkText key=cjk-primary display='界' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 13-14 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 9-11 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-11 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
@@ -50,6 +52,8 @@ font 9-11 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGl
 font 11-12 role=CjkText key=cjk-primary display='世' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 12-13 role=CjkText key=cjk-primary display='界' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 13-14 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 9-11 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-11 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
@@ -79,6 +83,8 @@ font 9-11 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGl
 font 11-12 role=CjkText key=cjk-primary display='世' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 12-13 role=CjkText key=cjk-primary display='界' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 13-14 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 2-4 source='……' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
+role-override 9-11 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=conflicting-surrounding-script; paragraph-language=zh-Hans
 punct 2-3 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 3-4 '⋯' class=Ellipsis adv=16.0 body=16.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-11 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds

--- a/engine/src/jvmTest/resources/golden/layout-dumps/parenthetical-dash-pairs.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps/parenthetical-dash-pairs.txt
@@ -1,0 +1,267 @@
+fixture: parenthetical-dash-pairs
+text: 他彻夜想Jessica——Jessica是他的前女友——睡不着觉。地点——北京，时间——明天。
+maxWidth: 1024.0
+== greedy ==
+size 748.0x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-47 natural=756.0 adjusted=748.0 visual=748.0 repair=- candidates=- justify=-
+cluster 0-1 '他' adv=16.0
+cluster 1-2 '彻' adv=16.0
+cluster 2-3 '夜' adv=16.0
+cluster 3-4 '想' adv=16.0
+cluster 4-11 'Jessica' adv=114.0
+cluster 11-13 '⸺' adv=32.0
+cluster 13-20 'Jessica' adv=114.0
+cluster 20-21 '是' adv=16.0
+cluster 21-22 '他' adv=16.0
+cluster 22-23 '的' adv=16.0
+cluster 23-24 '前' adv=16.0
+cluster 24-25 '女' adv=16.0
+cluster 25-26 '友' adv=16.0
+cluster 26-28 '⸺' adv=32.0
+cluster 28-29 '睡' adv=16.0
+cluster 29-30 '不' adv=16.0
+cluster 30-31 '着' adv=16.0
+cluster 31-32 '觉' adv=16.0
+cluster 32-33 '。' adv=16.0
+cluster 33-34 '地' adv=16.0
+cluster 34-35 '点' adv=16.0
+cluster 35-37 '⸺' adv=32.0
+cluster 37-38 '北' adv=16.0
+cluster 38-39 '京' adv=16.0
+cluster 39-40 '，' adv=16.0
+cluster 40-41 '时' adv=16.0
+cluster 41-42 '间' adv=16.0
+cluster 42-44 '⸺' adv=32.0
+cluster 44-45 '明' adv=16.0
+cluster 45-46 '天' adv=16.0
+cluster 46-47 '。' adv=8.0
+font 0-1 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='彻' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkText key=cjk-primary display='夜' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='想' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-11 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 13-20 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-21 role=CjkText key=cjk-primary display='是' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 21-22 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 22-23 role=CjkText key=cjk-primary display='的' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 23-24 role=CjkText key=cjk-primary display='前' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 24-25 role=CjkText key=cjk-primary display='女' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 25-26 role=CjkText key=cjk-primary display='友' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 26-28 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 28-29 role=CjkText key=cjk-primary display='睡' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 29-30 role=CjkText key=cjk-primary display='不' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 30-31 role=CjkText key=cjk-primary display='着' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 31-32 role=CjkText key=cjk-primary display='觉' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 32-33 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 33-34 role=CjkText key=cjk-primary display='地' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 34-35 role=CjkText key=cjk-primary display='点' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-37 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 37-38 role=CjkText key=cjk-primary display='北' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 38-39 role=CjkText key=cjk-primary display='京' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 39-40 role=CjkPunctuation key=cjk-primary display='，' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 40-41 role=CjkText key=cjk-primary display='时' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 41-42 role=CjkText key=cjk-primary display='间' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 42-44 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 44-45 role=CjkText key=cjk-primary display='明' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 45-46 role=CjkText key=cjk-primary display='天' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 46-47 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 26-28 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 35-37 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 42-44 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 26-28 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 32-33 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 35-37 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 39-40 '，' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 42-44 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 46-47 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+geom 11-13 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 26-28 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 32-33 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 35-37 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 39-40 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 42-44 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 46-47 body=8.0 lead=0.0/0.0 trail=8.0/8.0 justify=0.0 resolved=8.0
+autospace 4-11 side=leading boundary=EastAsianSpacing.Wide reduction=-2.0
+autospace 13-20 side=trailing boundary=EastAsianSpacing.Wide reduction=-2.0
+edgetrim 46-47 side=trailing trim=8.0 reason=LineEndHalfWidthPunctuation
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== lookahead ==
+size 748.0x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-47 natural=756.0 adjusted=748.0 visual=748.0 repair=- candidates=- justify=-
+cluster 0-1 '他' adv=16.0
+cluster 1-2 '彻' adv=16.0
+cluster 2-3 '夜' adv=16.0
+cluster 3-4 '想' adv=16.0
+cluster 4-11 'Jessica' adv=114.0
+cluster 11-13 '⸺' adv=32.0
+cluster 13-20 'Jessica' adv=114.0
+cluster 20-21 '是' adv=16.0
+cluster 21-22 '他' adv=16.0
+cluster 22-23 '的' adv=16.0
+cluster 23-24 '前' adv=16.0
+cluster 24-25 '女' adv=16.0
+cluster 25-26 '友' adv=16.0
+cluster 26-28 '⸺' adv=32.0
+cluster 28-29 '睡' adv=16.0
+cluster 29-30 '不' adv=16.0
+cluster 30-31 '着' adv=16.0
+cluster 31-32 '觉' adv=16.0
+cluster 32-33 '。' adv=16.0
+cluster 33-34 '地' adv=16.0
+cluster 34-35 '点' adv=16.0
+cluster 35-37 '⸺' adv=32.0
+cluster 37-38 '北' adv=16.0
+cluster 38-39 '京' adv=16.0
+cluster 39-40 '，' adv=16.0
+cluster 40-41 '时' adv=16.0
+cluster 41-42 '间' adv=16.0
+cluster 42-44 '⸺' adv=32.0
+cluster 44-45 '明' adv=16.0
+cluster 45-46 '天' adv=16.0
+cluster 46-47 '。' adv=8.0
+font 0-1 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='彻' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkText key=cjk-primary display='夜' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='想' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-11 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 13-20 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-21 role=CjkText key=cjk-primary display='是' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 21-22 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 22-23 role=CjkText key=cjk-primary display='的' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 23-24 role=CjkText key=cjk-primary display='前' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 24-25 role=CjkText key=cjk-primary display='女' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 25-26 role=CjkText key=cjk-primary display='友' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 26-28 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 28-29 role=CjkText key=cjk-primary display='睡' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 29-30 role=CjkText key=cjk-primary display='不' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 30-31 role=CjkText key=cjk-primary display='着' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 31-32 role=CjkText key=cjk-primary display='觉' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 32-33 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 33-34 role=CjkText key=cjk-primary display='地' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 34-35 role=CjkText key=cjk-primary display='点' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-37 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 37-38 role=CjkText key=cjk-primary display='北' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 38-39 role=CjkText key=cjk-primary display='京' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 39-40 role=CjkPunctuation key=cjk-primary display='，' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 40-41 role=CjkText key=cjk-primary display='时' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 41-42 role=CjkText key=cjk-primary display='间' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 42-44 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 44-45 role=CjkText key=cjk-primary display='明' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 45-46 role=CjkText key=cjk-primary display='天' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 46-47 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 26-28 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 35-37 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 42-44 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 26-28 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 32-33 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 35-37 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 39-40 '，' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 42-44 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 46-47 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+geom 11-13 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 26-28 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 32-33 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 35-37 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 39-40 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 42-44 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 46-47 body=8.0 lead=0.0/0.0 trail=8.0/8.0 justify=0.0 resolved=8.0
+autospace 4-11 side=leading boundary=EastAsianSpacing.Wide reduction=-2.0
+autospace 13-20 side=trailing boundary=EastAsianSpacing.Wide reduction=-2.0
+edgetrim 46-47 side=trailing trim=8.0 reason=LineEndHalfWidthPunctuation
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault
+== paragraph-dp ==
+size 748.0x24.0
+kinsoku measure=64.0字 level=Strict hang=Disabled reason=MeasureAdaptiveKinsoku:64字→Strict
+line[0] 0-47 natural=756.0 adjusted=748.0 visual=748.0 repair=- candidates=- justify=-
+cluster 0-1 '他' adv=16.0
+cluster 1-2 '彻' adv=16.0
+cluster 2-3 '夜' adv=16.0
+cluster 3-4 '想' adv=16.0
+cluster 4-11 'Jessica' adv=114.0
+cluster 11-13 '⸺' adv=32.0
+cluster 13-20 'Jessica' adv=114.0
+cluster 20-21 '是' adv=16.0
+cluster 21-22 '他' adv=16.0
+cluster 22-23 '的' adv=16.0
+cluster 23-24 '前' adv=16.0
+cluster 24-25 '女' adv=16.0
+cluster 25-26 '友' adv=16.0
+cluster 26-28 '⸺' adv=32.0
+cluster 28-29 '睡' adv=16.0
+cluster 29-30 '不' adv=16.0
+cluster 30-31 '着' adv=16.0
+cluster 31-32 '觉' adv=16.0
+cluster 32-33 '。' adv=16.0
+cluster 33-34 '地' adv=16.0
+cluster 34-35 '点' adv=16.0
+cluster 35-37 '⸺' adv=32.0
+cluster 37-38 '北' adv=16.0
+cluster 38-39 '京' adv=16.0
+cluster 39-40 '，' adv=16.0
+cluster 40-41 '时' adv=16.0
+cluster 41-42 '间' adv=16.0
+cluster 42-44 '⸺' adv=32.0
+cluster 44-45 '明' adv=16.0
+cluster 45-46 '天' adv=16.0
+cluster 46-47 '。' adv=8.0
+font 0-1 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 1-2 role=CjkText key=cjk-primary display='彻' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 2-3 role=CjkText key=cjk-primary display='夜' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 3-4 role=CjkText key=cjk-primary display='想' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 4-11 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 11-13 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 13-20 role=LatinText key=latin-primary display='Jessica' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 20-21 role=CjkText key=cjk-primary display='是' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 21-22 role=CjkText key=cjk-primary display='他' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 22-23 role=CjkText key=cjk-primary display='的' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 23-24 role=CjkText key=cjk-primary display='前' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 24-25 role=CjkText key=cjk-primary display='女' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 25-26 role=CjkText key=cjk-primary display='友' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 26-28 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 28-29 role=CjkText key=cjk-primary display='睡' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 29-30 role=CjkText key=cjk-primary display='不' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 30-31 role=CjkText key=cjk-primary display='着' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 31-32 role=CjkText key=cjk-primary display='觉' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 32-33 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 33-34 role=CjkText key=cjk-primary display='地' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 34-35 role=CjkText key=cjk-primary display='点' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 35-37 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 37-38 role=CjkText key=cjk-primary display='北' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 38-39 role=CjkText key=cjk-primary display='京' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 39-40 role=CjkPunctuation key=cjk-primary display='，' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 40-41 role=CjkText key=cjk-primary display='时' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 41-42 role=CjkText key=cjk-primary display='间' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 42-44 role=CjkPunctuation key=cjk-primary display='⸺' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:U+2014+U+2014->U+2E3A
+font 44-45 role=CjkText key=cjk-primary display='明' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 45-46 role=CjkText key=cjk-primary display='天' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+font 46-47 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 11-13 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 26-28 source='——' CjkPunctuation->CjkPunctuation policy=ParagraphLanguageDashEllipsisContext reason=parenthetical-pair-conflicting-outer-script; paragraph-language=zh-Hans
+role-override 35-37 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 42-44 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+punct 11-13 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 26-28 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 32-33 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 35-37 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 39-40 '，' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 42-44 '⸺' class=Dash adv=32.0 body=32.0 lead=0.0 trail=0.0 anchor=Center source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+punct 46-47 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
+geom 11-13 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 26-28 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 32-33 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 35-37 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 39-40 body=8.0 lead=0.0/0.0 trail=0.0/8.0 justify=0.0 resolved=16.0
+geom 42-44 body=32.0 lead=0.0/0.0 trail=0.0/0.0 justify=0.0 resolved=32.0
+geom 46-47 body=8.0 lead=0.0/0.0 trail=8.0/8.0 justify=0.0 resolved=8.0
+autospace 4-11 side=leading boundary=EastAsianSpacing.Wide reduction=-2.0
+autospace 13-20 side=trailing boundary=EastAsianSpacing.Wide reduction=-2.0
+edgetrim 46-47 side=trailing trim=8.0 reason=LineEndHalfWidthPunctuation
+linespacing natural=16.0 requested=- resolved=24.0 floor=0.0 applied=false reason=CjkBodyLineHeightDefault

--- a/engine/src/jvmTest/resources/golden/layout-dumps/real-paragraph-1.txt
+++ b/engine/src/jvmTest/resources/golden/layout-dumps/real-paragraph-1.txt
@@ -353,6 +353,9 @@ font 181-182 role=CjkText key=cjk-primary display='太' sub=CjkPunctuationGlyphP
 font 182-183 role=CjkText key=cjk-primary display='离' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 183-184 role=CjkText key=cjk-primary display='谱' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 184-185 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 62-64 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 130-132 source='……' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 punct 2-3 '（' class=Opening adv=16.0 body=8.0 lead=8.0 trail=0.0 anchor=Trailing source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-10 '）' class=Closing adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 23-24 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
@@ -755,6 +758,9 @@ font 181-182 role=CjkText key=cjk-primary display='太' sub=CjkPunctuationGlyphP
 font 182-183 role=CjkText key=cjk-primary display='离' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 183-184 role=CjkText key=cjk-primary display='谱' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 184-185 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 62-64 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 130-132 source='……' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 punct 2-3 '（' class=Opening adv=16.0 body=8.0 lead=8.0 trail=0.0 anchor=Trailing source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-10 '）' class=Closing adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 23-24 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
@@ -1157,6 +1163,9 @@ font 181-182 role=CjkText key=cjk-primary display='太' sub=CjkPunctuationGlyphP
 font 182-183 role=CjkText key=cjk-primary display='离' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 183-184 role=CjkText key=cjk-primary display='谱' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
 font 184-185 role=CjkPunctuation key=cjk-primary display='。' sub=CjkPunctuationGlyphPolicy:PreferClreqRecommendedCodepoints:preserve
+role-override 62-64 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 75-77 source='——' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
+role-override 130-132 source='……' CjkPunctuation->CjkPunctuation policy=DashEllipsisSurroundingScriptContext reason=matching-surrounding-script
 punct 2-3 '（' class=Opening adv=16.0 body=8.0 lead=8.0 trail=0.0 anchor=Trailing source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 9-10 '）' class=Closing adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds
 punct 23-24 '。' class=PauseOrStop adv=16.0 body=8.0 lead=0.0 trail=8.0 anchor=Leading source=ProfileGlueFallbackWithoutFontGeometry fallback=shaper-no-ink-bounds

--- a/engine/src/jvmTest/resources/golden/shaping-evidence.json
+++ b/engine/src/jvmTest/resources/golden/shaping-evidence.json
@@ -27898,6 +27898,1033 @@
         },
         {
             "key": {
+                "displayText": "—",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkPunctuation",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 467,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -8.0,
+                            16.0,
+                            -4.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "⋯",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkPunctuation",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 479,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -9.0,
+                            16.0,
+                            -4.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "—",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 1462,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -7.0,
+                            17.0,
+                            -3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "next;",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 36.953125,
+                "runAdvance": 36.953125,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 773,
+                        "advance": 9.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -10.0,
+                            10.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 614,
+                        "advance": 8.640625,
+                        "x": 9.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            10.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 993,
+                        "advance": 9.3125,
+                        "x": 17.640625,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            10.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 889,
+                        "advance": 5.0,
+                        "x": 26.953125,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -12.0,
+                            6.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 1508,
+                        "advance": 5.0,
+                        "x": 31.953125,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -10.0,
+                            5.0,
+                            4.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 5,
+                        "advance": 36.953125,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "ellipsis",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 51.0,
+                "runAdvance": 51.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 614,
+                        "advance": 9.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            10.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 736,
+                        "advance": 4.0,
+                        "x": 9.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -13.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 736,
+                        "advance": 4.0,
+                        "x": 13.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -13.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 689,
+                        "advance": 4.0,
+                        "x": 17.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -14.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 843,
+                        "advance": 10.0,
+                        "x": 21.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -10.0,
+                            10.0,
+                            5.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 871,
+                        "advance": 8.0,
+                        "x": 31.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 689,
+                        "advance": 4.0,
+                        "x": 39.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -14.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 871,
+                        "advance": 8.0,
+                        "x": 43.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 8,
+                        "advance": 51.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "…",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 14.0,
+                "runAdvance": 14.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 1503,
+                        "advance": 14.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -4.0,
+                            14.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 14.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "/",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 6.0,
+                "runAdvance": 6.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 1455,
+                        "advance": 6.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -14.0,
+                            7.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 6.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "slash.",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 43.0,
+                "runAdvance": 43.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 871,
+                        "advance": 8.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 736,
+                        "advance": 4.0,
+                        "x": 8.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -13.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 507,
+                        "advance": 9.0,
+                        "x": 12.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 871,
+                        "advance": 8.0,
+                        "x": 21.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 670,
+                        "advance": 9.0,
+                        "x": 29.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -13.0,
+                            10.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 1502,
+                        "advance": 5.0,
+                        "x": 38.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -4.0,
+                            5.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 6,
+                        "advance": 43.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "——",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 32.0,
+                "runAdvance": 32.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 1462,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -7.0,
+                            17.0,
+                            -3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 1462,
+                        "advance": 16.0,
+                        "x": 16.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -7.0,
+                            17.0,
+                            -3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 2,
+                        "advance": 32.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "B;",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 15.0,
+                "runAdvance": 15.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 65,
+                        "advance": 10.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -13.0,
+                            11.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 1508,
+                        "advance": 5.0,
+                        "x": 10.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -10.0,
+                            5.0,
+                            4.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 2,
+                        "advance": 15.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "Wait",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 33.1875,
+                "runAdvance": 33.1875,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 459,
+                        "advance": 15.1875,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -13.0,
+                            17.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 507,
+                        "advance": 9.0,
+                        "x": 15.1875,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 689,
+                        "advance": 4.0,
+                        "x": 24.1875,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -14.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 889,
+                        "advance": 5.0,
+                        "x": 28.1875,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -12.0,
+                            6.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 4,
+                        "advance": 33.1875,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "……",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 28.0,
+                "runAdvance": 28.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 1503,
+                        "advance": 14.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -4.0,
+                            14.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 1503,
+                        "advance": 14.0,
+                        "x": 14.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -4.0,
+                            14.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 2,
+                        "advance": 28.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "what?",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 44.0,
+                "runAdvance": 44.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 984,
+                        "advance": 13.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            14.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 670,
+                        "advance": 9.0,
+                        "x": 13.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -13.0,
+                            10.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 507,
+                        "advance": 9.0,
+                        "x": 22.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 889,
+                        "advance": 5.0,
+                        "x": 31.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -12.0,
+                            6.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 1431,
+                        "advance": 8.0,
+                        "x": 36.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -13.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 5,
+                        "advance": 44.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
                 "displayText": "le“t”ters",
                 "fontKey": "latin-primary",
                 "fontFamily": "latin-primary",
@@ -35452,6 +36479,226 @@
                 "source": "RawTables",
                 "typoAscent": 14.080001,
                 "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkPunctuation",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "—"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkPunctuation",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "⋯"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": " English "
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "—"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": " next; ellipsis"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "…"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": " / slash. A"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "——"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "B; Wait"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "……"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "what? "
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
             }
         },
         {

--- a/engine/src/jvmTest/resources/golden/shaping-evidence.json
+++ b/engine/src/jvmTest/resources/golden/shaping-evidence.json
@@ -28925,6 +28925,804 @@
         },
         {
             "key": {
+                "displayText": "彻",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 13227,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            16.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "夜",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 11603,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "想",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 13602,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "Jessica",
+                "fontKey": "latin-primary",
+                "fontFamily": "latin-primary",
+                "role": "LatinText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 56.15625,
+                "runAdvance": 56.15625,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 266,
+                        "advance": 9.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -13.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 614,
+                        "advance": 9.0,
+                        "x": 9.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            10.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 871,
+                        "advance": 8.0,
+                        "x": 18.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 871,
+                        "advance": 8.0,
+                        "x": 26.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 689,
+                        "advance": 4.0,
+                        "x": 34.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -14.0,
+                            4.0,
+                            1.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 586,
+                        "advance": 9.15625,
+                        "x": 38.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            10.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    },
+                    {
+                        "id": 507,
+                        "advance": 9.0,
+                        "x": 47.15625,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -10.0,
+                            9.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 7,
+                        "advance": 56.15625,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Inter Variable:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "前",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 9877,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "女",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 11688,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "友",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 10254,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "睡",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 19320,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -15.0,
+                            17.0,
+                            2.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "着",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 19287,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            16.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "觉",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 24012,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            0.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "点",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 17621,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "北",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 10077,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "京",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 8952,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -15.0,
+                            16.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
+                "displayText": "天",
+                "fontKey": "cjk-primary",
+                "fontFamily": "cjk-primary",
+                "role": "CjkText",
+                "styleFontFamilies": [],
+                "fontSize": 16.0,
+                "fontWeight": 400,
+                "italic": false,
+                "locale": "zh-Hans",
+                "openTypeFeatures": []
+            },
+            "result": {
+                "clusterAdvance": 16.0,
+                "runAdvance": 16.0,
+                "runFeatures": [],
+                "glyphs": [
+                    {
+                        "id": 11616,
+                        "advance": 16.0,
+                        "x": 0.0,
+                        "y": 0.0,
+                        "bounds": [
+                            -1.0,
+                            -14.0,
+                            17.0,
+                            3.0
+                        ],
+                        "haltAdvance": null,
+                        "haltPlacementX": null
+                    }
+                ],
+                "decisions": [
+                    {
+                        "glyphCount": 1,
+                        "advance": 16.0,
+                        "source": "Skia",
+                        "reason": "SkiaTextShaper:Source Han Sans CN:lang=zh-Hans",
+                        "glyphsWithoutInkBounds": 0,
+                        "missingGlyphs": 0,
+                        "resolvedFace": null,
+                        "script": null,
+                        "language": null,
+                        "strategy": null,
+                        "featureEvidence": null,
+                        "capabilityIssue": null
+                    }
+                ]
+            }
+        },
+        {
+            "key": {
                 "displayText": "le“t”ters",
                 "fontKey": "latin-primary",
                 "fontFamily": "latin-primary",
@@ -36699,6 +37497,286 @@
                 "source": "RawTables",
                 "typoAscent": 15.5,
                 "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "彻"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "夜"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "想"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "latin-primary",
+                "fontSize": 16.0,
+                "role": "LatinText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "Jessica"
+            },
+            "result": {
+                "ascent": 15.5,
+                "descent": 3.859375,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 15.5,
+                "typoDescent": 3.859375
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "前"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "女"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "友"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "睡"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "着"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "觉"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "点"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "北"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "京"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
+            }
+        },
+        {
+            "key": {
+                "fontKey": "cjk-primary",
+                "fontSize": 16.0,
+                "role": "CjkText",
+                "locale": "zh-Hans",
+                "fontFamilies": [],
+                "fontWeight": 400,
+                "italic": false,
+                "faceSelectionText": "天"
+            },
+            "result": {
+                "ascent": 18.560038,
+                "descent": 4.6080093,
+                "leading": 0.0,
+                "source": "RawTables",
+                "typoAscent": 14.080001,
+                "typoDescent": 1.9200001
             }
         },
         {

--- a/ffi/js/npm/README.md
+++ b/ffi/js/npm/README.md
@@ -16,7 +16,8 @@ the worker engine and the browser runtime always come from one engine build.
 - `fontFallbackResolve(text: string, start: number, end: number, requestJson: string): string` — resolve font fallback decision from JSON request.
 - `liangHyphenate(word: string, patternsJson: string, exceptionsJson: string, leftMin?: number, rightMin?: number): string` — hyphenate a word using Liang patterns and exceptions.
 - `unicodePunctuationLineBreakClassOf(codePoint: number): string` — return Unicode line break class name for a code point.
-- `classifyFontRole(text: string, start: number, end: number, locale: string): string` — classify font role for a text range.
+- `classifyFontRole(text: string, start: number, end: number, locale: string): string` — classify font role for a text range within the complete paragraph text.
+- `classifyFontRoles(text: string, starts: Array<number>, ends: Array<number>, locale: string): Array<string>` — classify several ranges against one complete paragraph, resolving contextual quote/dash/ellipsis roles once.
 - `unsupportedInlineShapingProperties(): Array<string>` — return ordered list of unsupported inline shaping CSS properties.
 - `firstDivergentInlineShapingProperty(elementValues: Array<string>, paragraphValues: Array<string>): string | null` — find first divergent property between element and paragraph value arrays.
 - `precomputePlainParagraph(...)` — plain paragraph plan; the full signature lives in `runtime/Tiqian-tiqian-ffi-js.d.mts`.

--- a/ffi/js/npm/package.test.mts
+++ b/ffi/js/npm/package.test.mts
@@ -87,6 +87,7 @@ interface FfiExports {
   liangHyphenate: (word: string, patternsJson: string, exceptionsJson: string, leftMin?: number, rightMin?: number) => string;
   unicodePunctuationLineBreakClassOf: (codePoint: number) => string;
   classifyFontRole: (text: string, start: number, end: number, locale: string) => string;
+  classifyFontRoles: (text: string, starts: number[], ends: number[], locale: string) => string[];
   unsupportedInlineShapingProperties: () => string[];
   firstDivergentInlineShapingProperty: (elementValues: string[], paragraphValues: string[]) => string | null;
   precomputeParagraphWithDiagnostics: (
@@ -143,6 +144,7 @@ test("the generated declarations name the whole export surface", async () => {
     "liangHyphenate",
     "unicodePunctuationLineBreakClassOf",
     "classifyFontRole",
+    "classifyFontRoles",
     "unsupportedInlineShapingProperties",
     "firstDivergentInlineShapingProperty",
     "precomputeParagraphWithDiagnostics",
@@ -183,6 +185,7 @@ test("the engine entry loads from the package exports surface", async () => {
   assert.equal(typeof ffi.liangHyphenate, "function");
   assert.equal(typeof ffi.unicodePunctuationLineBreakClassOf, "function");
   assert.equal(typeof ffi.classifyFontRole, "function");
+  assert.equal(typeof ffi.classifyFontRoles, "function");
   assert.equal(typeof ffi.unsupportedInlineShapingProperties, "function");
   assert.equal(typeof ffi.firstDivergentInlineShapingProperty, "function");
   assert.equal(typeof ffi.precomputeParagraphWithDiagnostics, "function");
@@ -196,6 +199,15 @@ test("classifyFontRole maps classifier roles to lowering role strings", async ()
   assert.equal(ffi.classifyFontRole("汉字", 0, 2, "zh-Hans"), "cjk-text");
   assert.equal(ffi.classifyFontRole("，", 0, 1, "zh-Hans"), "cjk-punctuation");
   assert.equal(ffi.classifyFontRole("Hello", 0, 5, "en"), "other");
+});
+
+test("classifyFontRoles resolves contextual marks from complete paragraph text", async () => {
+  const ffi = (await import("@tiqian/ffi")) as unknown as FfiExports;
+
+  assert.deepEqual(
+    ffi.classifyFontRoles("A——B中文……下句", [1, 2, 6, 7], [2, 3, 7, 8], "zh-Hans"),
+    ["other", "other", "cjk-punctuation", "cjk-punctuation"],
+  );
 });
 
 test("unsupportedInlineShapingProperties returns fresh ordered property array", async () => {

--- a/ffi/js/npm/package.test.mts
+++ b/ffi/js/npm/package.test.mts
@@ -210,6 +210,13 @@ test("classifyFontRoles resolves contextual marks from complete paragraph text",
   );
 });
 
+test("classifyFontRole resolves curly quotes through structural pair analysis", async () => {
+  const ffi = (await import("@tiqian/ffi")) as unknown as FfiExports;
+
+  assert.equal(ffi.classifyFontRole("word“中文”word", 4, 5, "zh-Hans"), "other");
+  assert.equal(ffi.classifyFontRole("word“中文”word", 7, 8, "zh-Hans"), "other");
+});
+
 test("unsupportedInlineShapingProperties returns fresh ordered property array", async () => {
   const ffi = (await import("@tiqian/ffi")) as unknown as FfiExports;
 

--- a/ffi/js/npm/verify-package.ts
+++ b/ffi/js/npm/verify-package.ts
@@ -95,6 +95,7 @@ export async function verifyPackage(packageRoot: URL = new URL("./", import.meta
     "liangHyphenate",
     "unicodePunctuationLineBreakClassOf",
     "classifyFontRole",
+    "classifyFontRoles",
     "unsupportedInlineShapingProperties",
     "firstDivergentInlineShapingProperty",
     "precomputePlainParagraph",

--- a/ffi/js/src/jsMain/kotlin/org/tiqian/ffi/js/LoweringHelperExports.kt
+++ b/ffi/js/src/jsMain/kotlin/org/tiqian/ffi/js/LoweringHelperExports.kt
@@ -10,6 +10,7 @@ import org.tiqian.font.FontRoleClassifier
 import org.tiqian.font.FontRoleContext
 import org.tiqian.font.InlineShapingStylePolicy
 import org.tiqian.layout.withContextualDashEllipsisRoles
+import org.tiqian.layout.withContextualQuoteRoles
 
 /**
  * Lowering helper exports consumed by the TypeScript markdown lowering engine
@@ -68,11 +69,26 @@ fun classifyFontRoles(
     }
 }
 
+private var cachedClassifierKey: Pair<String, String>? = null
+private var cachedClassifier: FontRoleClassifier = fontRoleClassifier
+
+/**
+ * Assembles the same base → quote-pair → dash/ellipsis classifier chain as the engine's
+ * `prepareWidthIndependentAnnotation`. A single-entry memo keyed on (text, locale) keeps
+ * repeated single-range calls over one paragraph at one resolution pass.
+ */
 private fun contextualFontRoleClassifier(
     text: String,
     context: FontRoleContext,
 ): FontRoleClassifier {
-    return fontRoleClassifier.withContextualDashEllipsisRoles(text, context)
+    val key = text to context.locale
+    if (cachedClassifierKey != key) {
+        cachedClassifier = fontRoleClassifier
+            .withContextualQuoteRoles(text, context)
+            .withContextualDashEllipsisRoles(text, context)
+        cachedClassifierKey = key
+    }
+    return cachedClassifier
 }
 
 private fun FontRole.toLoweringRoleName(): String = when (this) {

--- a/ffi/js/src/jsMain/kotlin/org/tiqian/ffi/js/LoweringHelperExports.kt
+++ b/ffi/js/src/jsMain/kotlin/org/tiqian/ffi/js/LoweringHelperExports.kt
@@ -6,8 +6,10 @@ import kotlin.js.JsExport
 import org.tiqian.core.TextRange
 import org.tiqian.font.CjkFontRoleClassifier
 import org.tiqian.font.FontRole
+import org.tiqian.font.FontRoleClassifier
 import org.tiqian.font.FontRoleContext
 import org.tiqian.font.InlineShapingStylePolicy
+import org.tiqian.layout.withContextualDashEllipsisRoles
 
 /**
  * Lowering helper exports consumed by the TypeScript markdown lowering engine
@@ -21,7 +23,7 @@ import org.tiqian.font.InlineShapingStylePolicy
 private val fontRoleClassifier = CjkFontRoleClassifier()
 
 /**
- * Classifies the typographic font role of the substring [text] in [start]..<[end].
+ * Classifies the typographic font role of [start]..<[end] within the complete paragraph [text].
  *
  * Maps [FontRole.CjkText] to `"cjk-text"`, [FontRole.CjkPunctuation] to `"cjk-punctuation"`,
  * and any other role (e.g. Latin, Symbol, Emoji, Unknown) to `"other"`.
@@ -33,16 +35,50 @@ fun classifyFontRole(
     end: Int,
     locale: String,
 ): String {
-    val role = fontRoleClassifier.classify(
+    val context = FontRoleContext(locale = locale)
+    val role = contextualFontRoleClassifier(text, context).classify(
         text = text,
         range = TextRange(start, end),
-        context = FontRoleContext(locale = locale),
+        context = context,
     )
-    return when (role) {
-        FontRole.CjkText -> "cjk-text"
-        FontRole.CjkPunctuation -> "cjk-punctuation"
-        else -> "other"
+    return role.toLoweringRoleName()
+}
+
+/**
+ * Classifies several ranges against one complete paragraph and resolves contextual dash and
+ * ellipsis roles once. The batch boundary keeps markdown lowering linear while preserving
+ * surrounding-script evidence across DOM text-node boundaries.
+ */
+@JsExport
+fun classifyFontRoles(
+    text: String,
+    starts: Array<Int>,
+    ends: Array<Int>,
+    locale: String,
+): Array<String> {
+    require(starts.size == ends.size) { "starts and ends must have the same size" }
+    val context = FontRoleContext(locale = locale)
+    val classifier = contextualFontRoleClassifier(text, context)
+    return Array(starts.size) { index ->
+        classifier.classify(
+            text = text,
+            range = TextRange(starts[index], ends[index]),
+            context = context,
+        ).toLoweringRoleName()
     }
+}
+
+private fun contextualFontRoleClassifier(
+    text: String,
+    context: FontRoleContext,
+): FontRoleClassifier {
+    return fontRoleClassifier.withContextualDashEllipsisRoles(text, context)
+}
+
+private fun FontRole.toLoweringRoleName(): String = when (this) {
+    FontRole.CjkText -> "cjk-text"
+    FontRole.CjkPunctuation -> "cjk-punctuation"
+    else -> "other"
 }
 
 /**

--- a/ffi/js/src/jsMain/kotlin/org/tiqian/ffi/js/LoweringHelperExports.kt
+++ b/ffi/js/src/jsMain/kotlin/org/tiqian/ffi/js/LoweringHelperExports.kt
@@ -69,7 +69,7 @@ fun classifyFontRoles(
     }
 }
 
-private var cachedClassifierKey: Pair<String, String>? = null
+private var cachedClassifierKey: Pair<String, FontRoleContext>? = null
 private var cachedClassifier: FontRoleClassifier = fontRoleClassifier
 
 /**
@@ -81,7 +81,7 @@ private fun contextualFontRoleClassifier(
     text: String,
     context: FontRoleContext,
 ): FontRoleClassifier {
-    val key = text to context.locale
+    val key = text to context
     if (cachedClassifierKey != key) {
         cachedClassifier = fontRoleClassifier
             .withContextualQuoteRoles(text, context)

--- a/ffi/js/src/jsTest/kotlin/org/tiqian/ffi/js/FontExportsTest.kt
+++ b/ffi/js/src/jsTest/kotlin/org/tiqian/ffi/js/FontExportsTest.kt
@@ -2,10 +2,24 @@ package org.tiqian.ffi.js
 
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class FontExportsTest {
+
+    @Test
+    fun loweringRoleBatchUsesCompleteParagraphContext() {
+        val text = "A——B中文……下句"
+        val starts = arrayOf(1, 2, 6, 7)
+        val ends = arrayOf(2, 3, 7, 8)
+
+        assertContentEquals(
+            arrayOf("other", "other", "cjk-punctuation", "cjk-punctuation"),
+            classifyFontRoles(text, starts, ends, "zh-Hans"),
+        )
+        assertEquals("other", classifyFontRole("A——B", 1, 2, "zh-Hans"))
+    }
 
     @Test
     fun fontMetricsResolveReturnsRawMetricsJsonForCjkRole() {

--- a/ffi/js/src/jsTest/kotlin/org/tiqian/ffi/js/FontExportsTest.kt
+++ b/ffi/js/src/jsTest/kotlin/org/tiqian/ffi/js/FontExportsTest.kt
@@ -22,6 +22,18 @@ class FontExportsTest {
     }
 
     @Test
+    fun loweringRoleUsesStructuralQuotePairResolution() {
+        val text = "word“中文”word"
+
+        assertEquals("other", classifyFontRole(text, 4, 5, "zh-Hans"))
+        assertEquals("other", classifyFontRole(text, 7, 8, "zh-Hans"))
+        assertContentEquals(
+            arrayOf("other", "cjk-text", "other"),
+            classifyFontRoles(text, arrayOf(4, 5, 7), arrayOf(5, 6, 8), "zh-Hans"),
+        )
+    }
+
+    @Test
     fun fontMetricsResolveReturnsRawMetricsJsonForCjkRole() {
         val requestJson =
             """{"fontKey":"cjk-key","fontSize":18,"role":"CjkText","locale":"zh-Hans","fontFamilies":["Source Han Sans"],"fontWeight":400,"italic":false,"faceSelectionText":"中"}"""

--- a/platforms/compose/compose/src/jvmTest/kotlin/org/tiqian/compose/ContextualDashEllipsisRoleTest.kt
+++ b/platforms/compose/compose/src/jvmTest/kotlin/org/tiqian/compose/ContextualDashEllipsisRoleTest.kt
@@ -1,0 +1,78 @@
+package org.tiqian.compose
+
+import org.tiqian.core.LayoutConstraints
+import org.tiqian.core.LayoutInput
+import org.tiqian.core.LayoutResult
+import org.tiqian.core.ParagraphStyle
+import org.tiqian.core.TextStyle
+import org.tiqian.core.TiqianTextContent
+import org.tiqian.core.ic
+import org.tiqian.font.FontRole
+import org.tiqian.layout.ExplainableStubParagraphLayoutEngine
+import org.tiqian.shaping.skia.SkiaFontMetricsResolver
+import org.tiqian.shaping.skia.SkiaTextShaper
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Real Desktop Skia coverage for contextual U+2014/U+2026 face selection. */
+class ContextualDashEllipsisRoleTest {
+    private val engine = ExplainableStubParagraphLayoutEngine(
+        textShaper = SkiaTextShaper(),
+        fontMetricsResolver = SkiaFontMetricsResolver(),
+    )
+
+    @Test
+    fun westernMarkCountDoesNotSwitchToTheCjkFace() {
+        val text = "English — next; ellipsis… A——B; Wait……what?"
+        val result = layout(text)
+
+        text.markIndices().forEach { index ->
+            val decision = result.fontDecisionAt(index)
+            assertEquals(FontRole.LatinText.name, decision.role, "index=$index $decision")
+            assertEquals(decision.sourceText, decision.displayText, "index=$index $decision")
+        }
+        assertTrue(result.debug.punctuationDecisions.none { it.char == '—' || it.char == '…' })
+        assertTrue(
+            result.debug.shapingDecisions
+                .filter { it.sourceText.any { char -> char.isContextualDashOrEllipsis() } }
+                .all { it.source == "Skia" && it.missingGlyphs == 0 },
+            result.debug.shapingDecisions.toString(),
+        )
+    }
+
+    @Test
+    fun cjkMarkCountDoesNotSwitchToTheLatinFace() {
+        val text = "中文—下句；等…真；中文——下句；省略号……。"
+        val result = layout(text)
+
+        text.markIndices().forEach { index ->
+            assertEquals(FontRole.CjkPunctuation.name, result.fontDecisionAt(index).role)
+        }
+        assertTrue(result.debug.punctuationDecisions.any { it.char == '—' })
+        assertTrue(result.debug.punctuationDecisions.any { it.char == '…' || it.char == '⋯' })
+        assertTrue(
+            result.debug.shapingDecisions
+                .filter { it.sourceText.any { char -> char.isContextualDashOrEllipsis() } }
+                .all { it.source == "Skia" },
+            result.debug.shapingDecisions.toString(),
+        )
+    }
+
+    private fun layout(text: String): LayoutResult = engine.layout(
+        LayoutInput(
+            content = TiqianTextContent(text),
+            textStyle = TextStyle(locale = "zh-Hans"),
+            paragraphStyle = ParagraphStyle(firstLineIndent = 0.ic),
+            constraints = LayoutConstraints(maxWidth = 1000f),
+        ),
+    )
+
+    private fun String.markIndices(): List<Int> = indices.filter { this[it].isContextualDashOrEllipsis() }
+
+    private fun Char.isContextualDashOrEllipsis(): Boolean = this == '—' || this == '…'
+
+    private fun LayoutResult.fontDecisionAt(index: Int) = debug.fontDecisions.single { decision ->
+        index >= decision.range.start && index < decision.range.end
+    }
+}

--- a/platforms/web/client/core/src/engine/canvas-shaping.ts
+++ b/platforms/web/client/core/src/engine/canvas-shaping.ts
@@ -789,9 +789,11 @@ export function createTextShaper(
 
   /**
    * Shape one segment, mirroring ShapingResult: ellipsis display
-   * substitution carries the UNVERIFIED issue pair, a CJK dash source (or
-   * the two-em-dash display) carries the CjkDashCapabilityPolicy issue, and
-   * everything else shapes plainly.
+   * substitution carries the UNVERIFIED issue pair, a CjkPunctuation-role
+   * dash source (or the two-em-dash display) carries the
+   * CjkDashCapabilityPolicy issue, and everything else shapes plainly.
+   * A Western-resolved `——` keeps its source display on the Latin face and
+   * needs no CJK dash capability.
    *
    * @param {ShapeInput} input
    * @returns {Object}
@@ -804,7 +806,10 @@ export function createTextShaper(
         detail: CANVAS_CANNOT_VERIFY_SAME_FACE_U22EF_COVERAGE,
       });
     }
-    if (source === CJK_DASH_SOURCE || input.displayText === TWO_EM_DASH) {
+    if (
+      (source === CJK_DASH_SOURCE && input.fontDecision.role === "CjkPunctuation") ||
+      input.displayText === TWO_EM_DASH
+    ) {
       return shapeWithCanvas(input, dashCapabilityIssue());
     }
     return shapeWithCanvas(input);

--- a/platforms/web/client/core/src/engine/lowered-paragraph.ts
+++ b/platforms/web/client/core/src/engine/lowered-paragraph.ts
@@ -219,3 +219,23 @@ export function preparedCjkStrongSemanticsJson(lowered: LoweredParagraph): strin
   result += "]";
   return result;
 }
+
+/** Field-wise equality over the [TextStyle] wire shape, null-tolerant. */
+export function textStylesEqual(left: TextStyle | null | undefined, right: TextStyle | null | undefined): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  if (
+    left.fontSize !== right.fontSize ||
+    left.fontWeight !== right.fontWeight ||
+    left.italic !== right.italic ||
+    left.baselineShift !== right.baselineShift ||
+    left.locale !== right.locale ||
+    left.fontFamilies.length !== right.fontFamilies.length
+  ) {
+    return false;
+  }
+  for (let i = 0; i < left.fontFamilies.length; i++) {
+    if (left.fontFamilies[i] !== right.fontFamilies[i]) return false;
+  }
+  return true;
+}

--- a/platforms/web/client/core/src/engine/markdown-lowering.ts
+++ b/platforms/web/client/core/src/engine/markdown-lowering.ts
@@ -18,6 +18,11 @@ import type {
   LineBreakSpan,
 } from "./lowered-paragraph.js";
 import { isNonTextInlineTag, isOpaqueInlineDisplay, isOpaqueInlineLevelDisplay } from "./eligibility.js";
+import {
+  appendProjectedStrongStyles,
+  type ClassifyRolesFn,
+  type PendingStrongTextRange,
+} from "./strong-emphasis-lowering.js";
 
 // --- Internal types (module-scoped) ---
 
@@ -54,7 +59,6 @@ interface LoweringOptions {
 }
 
 type ClassifyRoleFn = (text: string, start: number, end: number, locale: string) => string;
-
 interface InlineShapingDecisionResult {
   name: string;
   detail: string;
@@ -69,6 +73,7 @@ type InlineShapingDecisionFn = (
 /** Inline-shaping helpers provided by the host for role classification. */
 interface InlineShapingHelpers {
   classifyRole?: ClassifyRoleFn;
+  classifyRoles?: ClassifyRolesFn;
   inlineShapingProperties?: string[];
   inlineShapingDecision?: InlineShapingDecisionFn;
   [key: string]: unknown;
@@ -88,6 +93,7 @@ interface AppendNodeLike {
 /** Normalized inline-shaping helpers after null-guarding. */
 interface NormalizedInlineShapingHelpers {
   classifyRole: ClassifyRoleFn;
+  classifyRoles: ClassifyRolesFn;
   inlineShapingProperties: string[];
   inlineShapingDecision: InlineShapingDecisionFn;
 }
@@ -566,39 +572,6 @@ function collectShapingValues(element: Element, properties: string[]): string[] 
   return values;
 }
 
-let graphemeSegmenter: Intl.Segmenter | null = null;
-if (typeof Intl !== "undefined" && Intl.Segmenter) {
-  try {
-    graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
-  } catch (error) {
-    graphemeSegmenter = null;
-  }
-}
-
-// Grapheme boundaries as UTF-16 offsets, including 0 and the full length.
-// Falls back to code-point traversal when the host has no Intl.Segmenter,
-// mirroring lowererGraphemeBoundaries in WebEnhancerSupport.kt.
-function graphemeBoundaries(value: string): number[] {
-  const boundaries = [0];
-  if (graphemeSegmenter) {
-    const items = graphemeSegmenter.segment(value);
-    const iterator = items[Symbol.iterator]();
-    for (let step = iterator.next(); !step.done; step = iterator.next()) {
-      const index = step.value.index;
-      if (index > 0 && index < value.length) boundaries.push(index);
-    }
-  } else {
-    let offset = 0;
-    const points = Array.from(value);
-    for (let i = 0; i < points.length; i++) {
-      offset += points[i].length;
-      if (offset < value.length) boundaries.push(offset);
-    }
-  }
-  boundaries.push(value.length);
-  return boundaries;
-}
-
 // LocaleChannel: the lowerer must answer the same default locale as the
 // Kotlin core TextStyle ("zh-Hans") because locale travels into LayoutInput
 // and drives font selection plus the punctuation profile. An explicit
@@ -882,6 +855,7 @@ interface LoweringBuilderInstance {
   sourceBoundaries: number[];
   whitespaceModes: WhiteSpaceMode[];
   hardBreakOffsets: number[];
+  pendingStrongTextRanges: PendingStrongTextRange[];
 }
 
 interface LoweringBuilderMethods {
@@ -894,7 +868,6 @@ interface LoweringBuilderMethods {
   appendOpaqueInlineObject(element: Element, whiteSpace: WhiteSpaceMode): boolean;
   appendSemantic(element: Element, style: InlineStyleContext, depth: number, cjkStrongBaseWeight: number | null): boolean;
   appendText(value: string, style: InlineStyleContext): void;
-  appendStrongTextSegment(value: string, style: InlineStyleContext, isCjk: boolean, strongBaseWeight: number): void;
   appendTextSegment(value: string, style: TextStyle, whiteSpace: WhiteSpaceMode, emphasis: boolean): void;
   build(): LoweredParagraph;
 }
@@ -947,6 +920,7 @@ function LoweringBuilder(
   this.sourceBoundaries = [];
   this.whitespaceModes = [];
   this.hardBreakOffsets = [];
+  this.pendingStrongTextRanges = [];
 }
 
 LoweringBuilder.prototype.addBoundary = function (this: LoweringBuilder, offset: number): void {
@@ -1123,43 +1097,17 @@ LoweringBuilder.prototype.appendText = function (this: LoweringBuilder, value: s
     this.appendTextSegment(value, style.textStyle, style.whiteSpace, false);
     return;
   }
-  const boundaries = graphemeBoundaries(value);
-  let runStart = boundaries[0];
-  let runIsCjk = false;
-  let hasRun = false;
-  for (let i = 0; i + 1 < boundaries.length; i++) {
-    const start = boundaries[i];
-    const end = boundaries[i + 1];
-    if (end <= start) continue;
-    const role = this.helpers.classifyRole(value, start, end, style.textStyle.locale);
-    const isCjk = role === "cjk-text" || role === "cjk-punctuation";
-    if (hasRun && isCjk !== runIsCjk) {
-      this.appendStrongTextSegment(value.substring(runStart, start), style, runIsCjk, strongBaseWeight);
-      runStart = start;
-    }
-    runIsCjk = isCjk;
-    hasRun = true;
-  }
-  if (hasRun && runStart < value.length) {
-    this.appendStrongTextSegment(value.substring(runStart), style, runIsCjk, strongBaseWeight);
-  }
-};
-
-LoweringBuilder.prototype.appendStrongTextSegment = function (this: LoweringBuilder, value: string, style: InlineStyleContext, isCjk: boolean, strongBaseWeight: number): void {
-  let textStyle: TextStyle;
-  if (isCjk) {
-    textStyle = {
-      fontFamilies: style.textStyle.fontFamilies,
-      fontSize: style.textStyle.fontSize,
-      fontWeight: strongBaseWeight,
-      italic: style.textStyle.italic,
-      baselineShift: style.textStyle.baselineShift,
-      locale: style.textStyle.locale,
-    };
-  } else {
-    textStyle = style.textStyle;
-  }
-  this.appendTextSegment(value, textStyle, style.whiteSpace, isCjk);
+  const start = this.text.length;
+  this.appendRawText(value, style.whiteSpace);
+  const end = this.text.length;
+  this.pendingStrongTextRanges.push({
+    start: start,
+    end: end,
+    style: style.textStyle,
+    strongBaseWeight: strongBaseWeight,
+  });
+  this.addBoundary(start);
+  this.addBoundary(end);
 };
 
 LoweringBuilder.prototype.appendTextSegment = function (this: LoweringBuilder, value: string, style: TextStyle, whiteSpace: WhiteSpaceMode, emphasis: boolean): void {
@@ -1270,12 +1218,28 @@ LoweringBuilder.prototype.build = function (this: LoweringBuilder): LoweredParag
       inlineBoxStyle: item.inlineBoxStyle,
     };
   };
+  const spans = mapProjectedRanges(this.spans, projection, spanCopy);
+  const decorations = mapProjectedRanges(this.decorations, projection, decorationCopy);
+  appendProjectedStrongStyles(
+    this.pendingStrongTextRanges,
+    loweredText,
+    function (start: number, end: number): [number, number] | null {
+      return projectionRange(projection, start, end);
+    },
+    this.helpers.classifyRoles,
+    this.baseInlineStyle.textStyle,
+    textStylesEqual,
+    spans,
+    decorations,
+  );
+  spans.sort(function (left, right) { return left.start - right.start || left.end - right.end; });
+  decorations.sort(function (left, right) { return left.start - right.start || left.end - right.end; });
   return {
     text: loweredText,
     textStyle: this.baseInlineStyle.textStyle,
     lineHeight: this.baseLineHeight,
-    spans: mapProjectedRanges(this.spans, projection, spanCopy),
-    decorations: mapProjectedRanges(this.decorations, projection, decorationCopy),
+    spans: spans,
+    decorations: decorations,
     inlineBoxes: mapProjectedRanges(this.inlineBoxes, projection, inlineBoxCopy),
     inlineObjects: mapProjectedRanges(this.inlineObjects, projection, inlineObjectCopy),
     domInlineObjects: mapProjectedRanges(this.domInlineObjects, projection, domInlineObjectCopy),
@@ -1295,6 +1259,13 @@ export function lowerMarkdown(paragraph: Element, options: LoweringOptions, help
   const classifyRole = (helpers && typeof helpers.classifyRole === "function")
     ? helpers.classifyRole
     : function (): string { return "other"; };
+  const classifyRoles = (helpers && typeof helpers.classifyRoles === "function")
+    ? helpers.classifyRoles
+    : function (text: string, starts: number[], ends: number[], locale: string): string[] {
+        return starts.map(function (start, index) {
+          return classifyRole(text, start, ends[index], locale);
+        });
+      };
   const inlineShapingProperties: string[] = Array.isArray(helpers?.inlineShapingProperties)
     ? helpers.inlineShapingProperties
     : [];
@@ -1303,6 +1274,7 @@ export function lowerMarkdown(paragraph: Element, options: LoweringOptions, help
     : null;
   const safeHelpers: NormalizedInlineShapingHelpers = {
     classifyRole: classifyRole,
+    classifyRoles: classifyRoles,
     inlineShapingProperties: inlineShapingProperties,
     inlineShapingDecision: inlineShapingDecision as NormalizedInlineShapingHelpers["inlineShapingDecision"],
   };

--- a/platforms/web/client/core/src/engine/markdown-lowering.ts
+++ b/platforms/web/client/core/src/engine/markdown-lowering.ts
@@ -17,6 +17,7 @@ import type {
   DomSourceSpan,
   LineBreakSpan,
 } from "./lowered-paragraph.js";
+import { textStylesEqual } from "./lowered-paragraph.js";
 import { isNonTextInlineTag, isOpaqueInlineDisplay, isOpaqueInlineLevelDisplay } from "./eligibility.js";
 import {
   appendProjectedStrongStyles,
@@ -641,25 +642,6 @@ function computedInlineStyle(element: Element, fallback: InlineStyleContext): In
   };
 }
 
-function textStylesEqual(left: TextStyle | null | undefined, right: TextStyle | null | undefined): boolean {
-  if (left === right) return true;
-  if (!left || !right) return false;
-  if (
-    left.fontSize !== right.fontSize ||
-    left.fontWeight !== right.fontWeight ||
-    left.italic !== right.italic ||
-    left.baselineShift !== right.baselineShift ||
-    left.locale !== right.locale ||
-    left.fontFamilies.length !== right.fontFamilies.length
-  ) {
-    return false;
-  }
-  for (let i = 0; i < left.fontFamilies.length; i++) {
-    if (left.fontFamilies[i] !== right.fontFamilies[i]) return false;
-  }
-  return true;
-}
-
 function parseOpaqueInlineObjectGeometry(value: string): InlineObjectGeometry | null {
   const rawParts = String(value).split(",");
   const parts: number[] = [];
@@ -868,7 +850,7 @@ interface LoweringBuilderMethods {
   appendOpaqueInlineObject(element: Element, whiteSpace: WhiteSpaceMode): boolean;
   appendSemantic(element: Element, style: InlineStyleContext, depth: number, cjkStrongBaseWeight: number | null): boolean;
   appendText(value: string, style: InlineStyleContext): void;
-  appendTextSegment(value: string, style: TextStyle, whiteSpace: WhiteSpaceMode, emphasis: boolean): void;
+  appendTextSegment(value: string, style: TextStyle, whiteSpace: WhiteSpaceMode): void;
   build(): LoweredParagraph;
 }
 
@@ -1094,7 +1076,7 @@ LoweringBuilder.prototype.appendText = function (this: LoweringBuilder, value: s
   if (value.length === 0) return;
   const strongBaseWeight = style.cjkStrongBaseWeight;
   if (strongBaseWeight === null || strongBaseWeight === undefined) {
-    this.appendTextSegment(value, style.textStyle, style.whiteSpace, false);
+    this.appendTextSegment(value, style.textStyle, style.whiteSpace);
     return;
   }
   const start = this.text.length;
@@ -1110,18 +1092,13 @@ LoweringBuilder.prototype.appendText = function (this: LoweringBuilder, value: s
   this.addBoundary(end);
 };
 
-LoweringBuilder.prototype.appendTextSegment = function (this: LoweringBuilder, value: string, style: TextStyle, whiteSpace: WhiteSpaceMode, emphasis: boolean): void {
+LoweringBuilder.prototype.appendTextSegment = function (this: LoweringBuilder, value: string, style: TextStyle, whiteSpace: WhiteSpaceMode): void {
   if (value.length === 0) return;
   const start = this.text.length;
   this.appendRawText(value, whiteSpace);
   const end = this.text.length;
   if (!textStylesEqual(style, this.baseInlineStyle.textStyle)) {
     this.spans.push({ start: start, end: end, style: style });
-    this.addBoundary(start);
-    this.addBoundary(end);
-  }
-  if (emphasis) {
-    this.decorations.push({ start: start, end: end, kind: "Emphasis" });
     this.addBoundary(start);
     this.addBoundary(end);
   }
@@ -1228,7 +1205,6 @@ LoweringBuilder.prototype.build = function (this: LoweringBuilder): LoweredParag
     },
     this.helpers.classifyRoles,
     this.baseInlineStyle.textStyle,
-    textStylesEqual,
     spans,
     decorations,
   );

--- a/platforms/web/client/core/src/engine/process-paragraph.ts
+++ b/platforms/web/client/core/src/engine/process-paragraph.ts
@@ -32,6 +32,7 @@ import {
 } from "./lifecycle.js";
 import {
   classifyFontRole,
+  classifyFontRoles,
   firstDivergentInlineShapingProperty,
   unsupportedInlineShapingProperties,
 } from "@tiqian/ffi";
@@ -109,6 +110,7 @@ interface ProcessInlineShapingDecisionResult {
   function loweringHelpers(): Record<string, unknown> {
     return {
       classifyRole: classifyFontRole,
+      classifyRoles: classifyFontRoles,
       inlineShapingDecision: function (tag: string, elementValues: string[], paragraphValues: string[]): ProcessInlineShapingDecisionResult | null {
         const property = firstDivergentInlineShapingProperty(elementValues, paragraphValues);
         return property == null ? null : { name: 'UnsupportedInlineShapingStyle', detail: tag + ':' + property };

--- a/platforms/web/client/core/src/engine/strong-emphasis-lowering.ts
+++ b/platforms/web/client/core/src/engine/strong-emphasis-lowering.ts
@@ -1,4 +1,5 @@
 import type { DecorationSpan, TextSpan, TextStyle } from "./lowered-paragraph.js";
+import { textStylesEqual } from "./lowered-paragraph.js";
 
 export type ClassifyRolesFn = (
   text: string,
@@ -21,7 +22,6 @@ interface ProjectedStrongCluster {
 }
 
 type ProjectRangeFn = (start: number, end: number) => [number, number] | null;
-type TextStylesEqualFn = (left: TextStyle, right: TextStyle) => boolean;
 
 let graphemeSegmenter: Intl.Segmenter | null = null;
 if (typeof Intl !== "undefined" && Intl.Segmenter) {
@@ -64,7 +64,6 @@ export function appendProjectedStrongStyles(
   projectRange: ProjectRangeFn,
   classifyRoles: ClassifyRolesFn,
   baseStyle: TextStyle,
-  textStylesEqual: TextStylesEqualFn,
   spans: TextSpan[],
   decorations: DecorationSpan[],
 ): void {

--- a/platforms/web/client/core/src/engine/strong-emphasis-lowering.ts
+++ b/platforms/web/client/core/src/engine/strong-emphasis-lowering.ts
@@ -1,0 +1,136 @@
+import type { DecorationSpan, TextSpan, TextStyle } from "./lowered-paragraph.js";
+
+export type ClassifyRolesFn = (
+  text: string,
+  starts: number[],
+  ends: number[],
+  locale: string,
+) => string[];
+
+export interface PendingStrongTextRange {
+  start: number;
+  end: number;
+  style: TextStyle;
+  strongBaseWeight: number;
+}
+
+interface ProjectedStrongCluster {
+  start: number;
+  end: number;
+  pendingIndex: number;
+}
+
+type ProjectRangeFn = (start: number, end: number) => [number, number] | null;
+type TextStylesEqualFn = (left: TextStyle, right: TextStyle) => boolean;
+
+let graphemeSegmenter: Intl.Segmenter | null = null;
+if (typeof Intl !== "undefined" && Intl.Segmenter) {
+  try {
+    graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  } catch (error) {
+    graphemeSegmenter = null;
+  }
+}
+
+function graphemeBoundaries(value: string): number[] {
+  const boundaries = [0];
+  if (graphemeSegmenter) {
+    const items = graphemeSegmenter.segment(value);
+    const iterator = items[Symbol.iterator]();
+    for (let step = iterator.next(); !step.done; step = iterator.next()) {
+      const index = step.value.index;
+      if (index > 0 && index < value.length) boundaries.push(index);
+    }
+  } else {
+    let offset = 0;
+    const points = Array.from(value);
+    for (let index = 0; index < points.length; index++) {
+      offset += points[index].length;
+      if (offset < value.length) boundaries.push(offset);
+    }
+  }
+  boundaries.push(value.length);
+  return boundaries;
+}
+
+/**
+ * Applies deferred strong-as-emphasis semantics after the complete paragraph
+ * and its whitespace projection are available. Role classification therefore
+ * sees context across DOM text-node boundaries and runs once per locale.
+ */
+export function appendProjectedStrongStyles(
+  pendingRanges: PendingStrongTextRange[],
+  loweredText: string,
+  projectRange: ProjectRangeFn,
+  classifyRoles: ClassifyRolesFn,
+  baseStyle: TextStyle,
+  textStylesEqual: TextStylesEqualFn,
+  spans: TextSpan[],
+  decorations: DecorationSpan[],
+): void {
+  const clusters: ProjectedStrongCluster[] = [];
+  for (let pendingIndex = 0; pendingIndex < pendingRanges.length; pendingIndex++) {
+    const pending = pendingRanges[pendingIndex];
+    const projected = projectRange(pending.start, pending.end);
+    if (!projected) continue;
+    const value = loweredText.substring(projected[0], projected[1]);
+    const boundaries = graphemeBoundaries(value);
+    for (let boundaryIndex = 0; boundaryIndex + 1 < boundaries.length; boundaryIndex++) {
+      const start = projected[0] + boundaries[boundaryIndex];
+      const end = projected[0] + boundaries[boundaryIndex + 1];
+      if (end > start) clusters.push({ start: start, end: end, pendingIndex: pendingIndex });
+    }
+  }
+  if (clusters.length === 0) return;
+
+  const roles = new Array<string>(clusters.length);
+  const clusterIndexesByLocale = new Map<string, number[]>();
+  for (let index = 0; index < clusters.length; index++) {
+    const locale = pendingRanges[clusters[index].pendingIndex].style.locale;
+    const existingIndexes = clusterIndexesByLocale.get(locale);
+    const localeIndexes = existingIndexes !== undefined ? existingIndexes : [];
+    localeIndexes.push(index);
+    clusterIndexesByLocale.set(locale, localeIndexes);
+  }
+  for (const [locale, clusterIndexes] of clusterIndexesByLocale) {
+    const starts = clusterIndexes.map(function (index) { return clusters[index].start; });
+    const ends = clusterIndexes.map(function (index) { return clusters[index].end; });
+    const localeRoles = classifyRoles(loweredText, starts, ends, locale);
+    for (let index = 0; index < clusterIndexes.length; index++) {
+      roles[clusterIndexes[index]] = localeRoles[index];
+    }
+  }
+
+  const appendRun = function (firstCluster: number, endCluster: number, isCjk: boolean): void {
+    const cluster = clusters[firstCluster];
+    const pending = pendingRanges[cluster.pendingIndex];
+    const start = cluster.start;
+    const end = clusters[endCluster - 1].end;
+    const style = isCjk
+      ? {
+          fontFamilies: pending.style.fontFamilies,
+          fontSize: pending.style.fontSize,
+          fontWeight: pending.strongBaseWeight,
+          italic: pending.style.italic,
+          baselineShift: pending.style.baselineShift,
+          locale: pending.style.locale,
+        }
+      : pending.style;
+    if (!textStylesEqual(style, baseStyle)) spans.push({ start: start, end: end, style: style });
+    if (isCjk) decorations.push({ start: start, end: end, kind: "Emphasis" });
+  };
+
+  let runStart = 0;
+  let runIsCjk = roles[0] === "cjk-text" || roles[0] === "cjk-punctuation";
+  for (let index = 1; index <= clusters.length; index++) {
+    const samePending = index < clusters.length &&
+      clusters[index].pendingIndex === clusters[runStart].pendingIndex;
+    const isCjk = index < clusters.length &&
+      (roles[index] === "cjk-text" || roles[index] === "cjk-punctuation");
+    if (!samePending || isCjk !== runIsCjk) {
+      appendRun(runStart, index, runIsCjk);
+      runStart = index;
+      runIsCjk = isCjk;
+    }
+  }
+}

--- a/platforms/web/client/core/src/engine/worker-request.ts
+++ b/platforms/web/client/core/src/engine/worker-request.ts
@@ -19,6 +19,7 @@ import type { EnhanceOptions } from "./lifecycle.js";
 import { allowsSnapshotLayout, conformingSnapshotFontSessionId, withRootDefaults } from "./lifecycle.js";
 import {
   classifyFontRole,
+  classifyFontRoles,
   firstDivergentInlineShapingProperty,
   unsupportedInlineShapingProperties,
 } from "@tiqian/ffi";
@@ -273,8 +274,9 @@ export function workerLayoutRequestForRoot(root: Element, paragraph: Element, op
       strongAsEmphasisMarks: resolved.strongAsEmphasisMarks as boolean | undefined,
       locale: 'zh-Hans',
     }, {
-      // classifyRole is the ffi export verbatim.
+      // Singular and batch role classifiers are the ffi exports verbatim.
       classifyRole: classifyFontRole,
+      classifyRoles: classifyFontRoles,
       // The inlineShapingDecision wrapper reproduces the Kotlin closure in
       // MarkdownParagraphLowering.kt: a null divergence property returns null,
       // otherwise the inlineShapingDecisionResultJs shape is built.

--- a/platforms/web/client/core/tests/canvas-shaping.test.ts
+++ b/platforms/web/client/core/tests/canvas-shaping.test.ts
@@ -446,9 +446,13 @@ test("dash: CjkDashCapabilityPolicy issue name and detail variants", () => {
     cjkDashCapability: { status: "conforming", detail: null },
     measureText: (): CanvasTextMetricsLike => ({ ...defaultMetrics(), width: 38 }),
   });
-  const cResult: CanvasShapingResult = conforming.shaper.shape(
-    input({ text: "\u2014\u2014", range: { start: 0, end: 2 }, displayText: "\u2014\u2014" }),
-  );
+  const cjkDashInput = (): ShapeInput => input({
+    text: "\u2014\u2014",
+    range: { start: 0, end: 2 },
+    displayText: "\u2014\u2014",
+    fontDecision: { role: "CjkPunctuation", candidate: { key: "k1" } },
+  });
+  const cResult: CanvasShapingResult = conforming.shaper.shape(cjkDashInput());
   assert.equal(cResult.decisions[0].capabilityIssue, "ConformingCjkDashRequiresSnapshotFontSession");
   assert.ok(cResult.decisions[0].reason.includes("; status=conforming"));
 
@@ -456,9 +460,7 @@ test("dash: CjkDashCapabilityPolicy issue name and detail variants", () => {
     cjkDashCapability: { status: "partial", detail: "probe-detail" },
     measureText: (): CanvasTextMetricsLike => ({ ...defaultMetrics(), width: 38 }),
   });
-  const pResult: CanvasShapingResult = partial.shaper.shape(
-    input({ text: "\u2014\u2014", range: { start: 0, end: 2 }, displayText: "\u2014\u2014" }),
-  );
+  const pResult: CanvasShapingResult = partial.shaper.shape(cjkDashInput());
   assert.equal(pResult.decisions[0].capabilityIssue, "NoConformingCjkDashGlyph");
   assert.ok(pResult.decisions[0].reason.includes("; status=partial; probe-detail"));
 
@@ -466,11 +468,25 @@ test("dash: CjkDashCapabilityPolicy issue name and detail variants", () => {
     cjkDashCapability: null,
     measureText: (): CanvasTextMetricsLike => ({ ...defaultMetrics(), width: 38 }),
   });
-  const nResult: CanvasShapingResult = none.shaper.shape(
-    input({ text: "\u2014\u2014", range: { start: 0, end: 2 }, displayText: "\u2014\u2014" }),
-  );
+  const nResult: CanvasShapingResult = none.shaper.shape(cjkDashInput());
   assert.equal(nResult.decisions[0].capabilityIssue, "NoConformingCjkDashGlyph");
   assert.ok(nResult.decisions[0].reason.includes("; CjkDashFontShapingNotPrepared"));
+});
+
+test("dash: a Western-resolved source \u2014\u2014 carries no CJK dash capability issue", () => {
+  const { shaper } = makeHarness({
+    cjkDashCapability: null,
+    measureText: (): CanvasTextMetricsLike => ({ ...defaultMetrics(), width: 38 }),
+  });
+  const result: CanvasShapingResult = shaper.shape(
+    input({
+      text: "\u2014\u2014",
+      range: { start: 0, end: 2 },
+      displayText: "\u2014\u2014",
+      fontDecision: { role: "LatinText", candidate: { key: "k1" } },
+    }),
+  );
+  assert.equal(result.decisions[0].capabilityIssue, null);
 });
 
 test("ellipsis: unverified display substitution carries the U+22EF issue", () => {

--- a/platforms/web/client/core/tests/process-paragraph.test.ts
+++ b/platforms/web/client/core/tests/process-paragraph.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { globalServices, initializeGlobalServices } from "../src/services/global-services.js";
 import { processParagraph } from "../src/engine/process-paragraph.js";
+import { lowerMarkdown } from "../src/engine/markdown-lowering.js";
 import { createEnhanceContext } from "../src/engine/context/enhance-context.js";
 import { optionsFromJs } from "../src/engine/lifecycle.js";
 import { effectiveLineMeasure } from "../src/engine/responsive-measure.js";
@@ -12,6 +13,7 @@ import { FakeElement, FakeFragment, FakeNode, FakeText, asElement, asFakeElement
 import type { EnhancedElementContext } from "../src/engine/context/enhance-context.js";
 import type { TiqianLayoutWorkerInstance } from "../src/engine/coordination/coordination-service.js";
 import type { ReplayProbe, ReplayRegistry } from "../src/measurement/browser-font-replay.js";
+import { classifyFontRole, classifyFontRoles } from "@tiqian/ffi";
 initializeGlobalServices();
 
 // The pipeline runs for real: eligibility, markdown lowering, the lifecycle
@@ -341,6 +343,32 @@ function strongChild(text: string): FakeElement {
   writeComputedValues(element, { display: "inline", "font-weight": "normal" });
   return element;
 }
+
+test("strong emphasis classifies contextual marks against the complete paragraph", () => {
+  withEnv(() => {
+    const children = [strongChild("A"), strongChild("——"), strongChild("B")];
+    for (const child of children) {
+      writeComputedValues(child, { display: "inline", "font-weight": "700" });
+    }
+    const paragraph = makeParagraphElement({
+      childNodes: children,
+    });
+    const result = lowerMarkdown(
+      asElement(paragraph),
+      { strongAsEmphasisMarks: true, locale: "zh-Hans" },
+      { classifyRole: classifyFontRole, classifyRoles: classifyFontRoles },
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.lowered.text, "A——B");
+    assert.deepEqual(result.lowered.decorations, []);
+    assert.deepEqual(
+      result.lowered.spans.map(function (span) { return [span.start, span.end, span.style.fontWeight]; }),
+      [[0, 1, 700], [1, 3, 700], [3, 4, 700]],
+    );
+  });
+});
 
 // A block-level child fails lowering with UnsupportedInlineFormattingContext.
 function blockChild(tagName: string, text: string): FakeElement {

--- a/test-support/src/commonMain/kotlin/org/tiqian/test/LayoutFixtures.kt
+++ b/test-support/src/commonMain/kotlin/org/tiqian/test/LayoutFixtures.kt
@@ -483,6 +483,16 @@ object EarlyLayoutFixtures {
                 "only-right evidence (——中文), and the no-context paragraph-language fallback (……).",
         ),
         LayoutFixture(
+            id = "parenthetical-dash-pairs",
+            text = "他彻夜想Jessica——Jessica是他的前女友——睡不着觉。地点——北京，时间——明天。",
+            constraints = LayoutConstraints(maxWidth = 1024f),
+            notes = "ParentheticalDashPairContext: the Jessica insertion pair resolves jointly " +
+                "from the outer context (conflict -> paragraph language -> CJK two-em dashes) " +
+                "even though the first run sits between Latin words; the second sentence's " +
+                "runs are separated by a comma, stay independent, and resolve from their own " +
+                "surroundings.",
+        ),
+        LayoutFixture(
             id = "quote-digit-boundaries",
             text = "中文 le“t”ters 中1“1”2文；中Ａ“Ｂ”Ｃ文。尾号是“1‘2’3”，用时1’30”。",
             constraints = LayoutConstraints(maxWidth = 1024f),

--- a/test-support/src/commonMain/kotlin/org/tiqian/test/LayoutFixtures.kt
+++ b/test-support/src/commonMain/kotlin/org/tiqian/test/LayoutFixtures.kt
@@ -472,6 +472,17 @@ object EarlyLayoutFixtures {
             ),
         ),
         LayoutFixture(
+            id = "contextual-dash-ellipsis",
+            text = "中文—下句；等…真。 English — next; ellipsis… / slash. A——B; Wait……what? " +
+                "中文—English\n——中文\n……",
+            constraints = LayoutConstraints(maxWidth = 1024f),
+            notes = "ContextualDashEllipsisRoleResolution uses surrounding strong script, not mark count: " +
+                "single CJK marks retain CJK geometry while repeated Western marks stay on the Latin face " +
+                "in their own clusters (ContextualDashEllipsisRunSegmentation). The tail exercises " +
+                "conflicting-surrounding-script (中文—English), mandatory-break truncation with " +
+                "only-right evidence (——中文), and the no-context paragraph-language fallback (……).",
+        ),
+        LayoutFixture(
             id = "quote-digit-boundaries",
             text = "中文 le“t”ters 中1“1”2文；中Ａ“Ｂ”Ｃ文。尾号是“1‘2’3”，用时1’30”。",
             constraints = LayoutConstraints(maxWidth = 1024f),


### PR DESCRIPTION
## 内容

U+2014 破折号与 U+2026 省略号不再按码点一律归 CJK：连续标记形成 source run，字体角色由 run 两侧最近的强脚本文本决定（两侧一致或仅一侧有证据时继承该侧，冲突或无证据时回退段落 locale，强制换行截断搜索）。CLREQ display 码点替换（`——`→`⸺`、`……`→`⋯⋯` 等）由 `CjkRoleGatedDisplaySubstitution` 限制在最终判为 `CjkPunctuation` 的 run。中文 `中—文`、`等…真` 单个标点仍用 CJK 几何；西文 `A——B`、`Wait……what` 重复标点也保持 Latin face 与 source display。

配套改动：

- `ParentheticalDashPairContext`：相邻等长的纯破折号 run、中间内容全为词字符或空格时构成插入语对，按对外侧最近强脚本联合决议（冲突回段落 locale），插入内容不投票——`想Jessica——Jessica是他的前女友——睡不着` 两个破折号同为 CJK 面；间隔含句读则各自独立，省略号不配对。
- `ContextualDashEllipsisRunSegmentation`：判为西文的 run 保持独立 cluster，不并入相邻 Latin 词簇，断行机会与角色解析前一致。
- web 端 canvas shaper 的 CJK 破折号 capability 检查改按 font role 门控，西文 `——` 不再触发整段回退原生渲染。
- FFI 新增批量 `classifyFontRoles`；lowering 分类器组装与 pipeline 对齐（base → quote-pair → dash/ellipsis），并按 (text, locale) 记忆化。
- web 端 strong-as-emphasis lowering 延迟到整段空白投影完成后批量取角色，跨 DOM text node 的标记不再丢失段落脚本上下文。
- `substitute()` 收为 internal，`substituteForRole` 是唯一角色感知入口。
- 决策进入 `LayoutResult.debug.roleOverrides`；golden fixture 覆盖 matching / conflicting / only-right / no-context 四条路径；ADR 0003 修正案与 audit、architecture 同步。

## 验证

- `:engine:jvmTest` 517 全过，golden 逐项核对（其余 fixture 零 diff）
- `:ffi:js:jsNodeTest`、`assembleNpmPackage` + npm 包测试
- web core 446、web-component、compose jvmTest（真实 Skia shaping）、`compileAndroidMain`
- layout report 已生成；`git diff --check` 与 doc-style 脚本通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
